### PR TITLE
Update "browserslist" specification

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+LICENSE

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "format": "prettier . --check",
     "format:fix": "prettier . --write",
     "verify": "run format",
-    "versions": "echo '[node]' && node --version && echo '\n[yarn]' && yarn --version && echo '\n[prettier]' && prettier --version"
+    "versions": "echo '[node]' && node --version && echo '\n[yarn]' && yarn --version && echo '\n[prettier]' && prettier --version && echo '\n[browserslist]' && browserslist --version"
   },
   "packageManager": "yarn@4.2.2",
   "devDependencies": {
-    "prettier": "^3.2.5"
+    "browserslist": "^4.23.0",
+    "prettier": "^3.3.1"
   },
   "prettier": "@pandell/prettier-config"
 }

--- a/packages/browserslist-config/.npmignore
+++ b/packages/browserslist-config/.npmignore
@@ -1,0 +1,1 @@
+package.json.md

--- a/packages/browserslist-config/LICENSE
+++ b/packages/browserslist-config/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Pandell, an ESG company
+Copyright (c) 2024 Pandell, an ESG company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -21,10 +21,10 @@ Add the following to your `package.json`:
 
 ## Browser Support
 
-See [browserslist.dev](https://browserslist.dev/?q=ZGVmYXVsdHMgYW5kID4gMSUsIG5vdCBpZSAxMSwgbm90IG9wX21pbmkgYWxs) for the latest browsers covered by our syntax.
+See [browserslist.dev](https://browserslist.dev/?q=ZGVmYXVsdHMgYW5kID4gMSUsIGxhc3QgMiBDaHJvbWUgdmVyc2lvbnMsIG5vdCBkZWFkLCBub3Qgb3BfbWluaSBhbGw%3D) for the latest browsers covered by our syntax.
 
 We use the following browserslist query:
 
 ```text
-defaults and > 1%, not ie 11, not op_mini all
+defaults and > 1%, last 2 Chrome versions, not dead, not op_mini all
 ```

--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,7 +1,5 @@
-/* eslint-env node */
-
 module.exports = {
-  development: ["defaults and > 1%, not ie 11, not op_mini all"],
-  production: ["defaults and > 1%, not ie 11, not op_mini all"],
+  development: ["defaults and > 1%, last 2 Chrome versions, not dead, not op_mini all"],
+  production: ["defaults and > 1%, last 2 Chrome versions, not dead, not op_mini all"],
   test: "current node",
 };

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/browserslist-config",
   "version": "4.0.4",
-  "description": "Pandell Browserslist Shared Config",
+  "description": "Pandell browserslist shared config",
   "keywords": [
     "browserslist",
     "browserslist-config",
@@ -22,7 +22,8 @@
   "scripts": {
     "browserslist:dev": "run -T browserslist --env=development",
     "browserslist:prod": "run -T browserslist --env=production",
-    "browserslist:test": "run -T browserslist --env=test"
+    "browserslist:test": "run -T browserslist --env=test",
+    "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "browserslist": [
     "extends @pandell/browserslist-config"

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,16 +1,17 @@
 {
   "name": "@pandell/browserslist-config",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Pandell Browserslist Shared Config",
   "keywords": [
-    "pandell",
-    "pli",
     "browserslist",
-    "browserslist-config"
+    "browserslist-config",
+    "pandell",
+    "pli"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pandell/web-pli"
+    "url": "https://github.com/pandell/frontend-config",
+    "directory": "packages/browserslist-config"
   },
   "license": "MIT",
   "author": {
@@ -19,11 +20,13 @@
   },
   "main": "./index.js",
   "scripts": {
-    "supported": "yarn supported:prod",
-    "supported:dev": "npx browserslist --env=development",
-    "supported:prod": "npx browserslist --env=production",
-    "supported:test": "npx browserslist --env=test"
+    "browserslist:dev": "run -T browserslist --env=development",
+    "browserslist:prod": "run -T browserslist --env=production",
+    "browserslist:test": "run -T browserslist --env=test"
   },
+  "browserslist": [
+    "extends @pandell/browserslist-config"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pandell/browserslist-config",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "Pandell browserslist shared config",
   "keywords": [
     "browserslist",

--- a/packages/browserslist-config/package.json.md
+++ b/packages/browserslist-config/package.json.md
@@ -1,0 +1,33 @@
+# Notes on Packages
+
+- [Version](#version)
+- [Scripts](#scripts)
+
+## Version
+
+Major version number should be following major version of `browserslist`
+in `frontend-config/package.json`.
+
+## Scripts
+
+### `browserslist:*`
+
+Scripts with `browserslist` prefix are used to print browsers that satisfy the Pandell
+specification (found in `packages/browserslist-config/index.js`) for our three environments
+(`development`, `production`, `test`). For example:
+
+```shell
+cd ~/development/frontend-config
+yarn workspace @pandell/browserslist-config run browserslist:dev
+# => and_chr 125
+# => chrome 125
+# => ...
+```
+
+The top-level `browserslist` property in `packages/browserslist-config/package.json`
+is required in order for the `browserslist` CLI tool to use our specification.
+Without it, `browserslist` prints browsers that satisfy the `default` specification,
+which is not what we are currently using.
+
+Please note that both `scripts` and `browserslist` top-level properties are removed
+from `package.json` during packaging (i.e. when publishing to NPM).

--- a/packages/eslint-config/LICENSE
+++ b/packages/eslint-config/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Pandell, an ESG company
+Copyright (c) 2024 Pandell, an ESG company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/jest-config/LICENSE
+++ b/packages/jest-config/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Pandell, an ESG company
+Copyright (c) 2024 Pandell, an ESG company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/prettier-config/LICENSE
+++ b/packages/prettier-config/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Pandell, an ESG company
+Copyright (c) 2024 Pandell, an ESG company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/stylelint-config/LICENSE
+++ b/packages/stylelint-config/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Pandell, an ESG company
+Copyright (c) 2024 Pandell, an ESG company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/typescript-config/LICENSE
+++ b/packages/typescript-config/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Pandell, an ESG company
+Copyright (c) 2024 Pandell, an ESG company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tools/clean-package-json.mjs
+++ b/tools/clean-package-json.mjs
@@ -11,7 +11,6 @@ delete packageJson.browserslist;
 delete packageJson.devDependencies;
 delete packageJson.scripts;
 
-// console.log(packageJson);
 const newPackageJsonString = JSON.stringify(packageJson, null, 2) + "\n";
 if (packageJsonString !== newPackageJsonString) {
   writeFileSync(packageJsonPath, newPackageJsonString, "utf8");

--- a/tools/clean-package-json.mjs
+++ b/tools/clean-package-json.mjs
@@ -1,0 +1,19 @@
+// Script run during packaging (see package.json) to tidy up the package.json
+// that is included with the released version.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const packageJsonPath = "./package.json";
+const packageJsonString = readFileSync(packageJsonPath, "utf8");
+const packageJson = JSON.parse(packageJsonString);
+
+delete packageJson.browserslist;
+delete packageJson.devDependencies;
+delete packageJson.scripts;
+
+// console.log(packageJson);
+const newPackageJsonString = JSON.stringify(packageJson, null, 2) + "\n";
+if (packageJsonString !== newPackageJsonString) {
+  writeFileSync(packageJsonPath, newPackageJsonString, "utf8");
+  console.log("Cleaned package.json");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,15 +174,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.23.0":
+  version: 4.23.0
+  resolution: "browserslist@npm:4.23.0"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001587"
+    electron-to-chromium: "npm:^1.4.668"
+    node-releases: "npm:^2.0.14"
+    update-browserslist-db: "npm:^1.0.13"
+  bin:
+    browserslist: cli.js
+  checksum: 10c0/8e9cc154529062128d02a7af4d8adeead83ca1df8cd9ee65a88e2161039f3d68a4d40fea7353cab6bae4c16182dec2fdd9a1cf7dc2a2935498cee1af0e998943
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001587":
+  version: 1.0.30001629
+  resolution: "caniuse-lite@npm:1.0.30001629"
+  checksum: 10c0/e95136a423c0c5e7f9d026ef3f9be8d06cadc4c83ad65eedfaeaba6b5eb814489ea186e90bae1085f3be7348577e25f8fe436b384c2f983324ad8dea4a7dfe1d
+  languageName: node
+  linkType: hard
+
 "debug@npm:^4.3.4":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
+  version: 4.3.5
+  resolution: "debug@npm:4.3.5"
   dependencies:
     ms: "npm:2.1.2"
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 10c0/cedbec45298dd5c501d01b92b119cd3faebe5438c3917ff11ae1bff86a6c722930ac9c8659792824013168ba6db7c4668225d845c633fbdafbbf902a6389f736
+  checksum: 10c0/082c375a2bdc4f4469c99f325ff458adad62a3fc2c482d59923c260cb08152f34e2659f72b3767db8bb2f21ca81a60a42d1019605a412132d7b9f59363a005cc
   languageName: node
   linkType: hard
 
@@ -192,6 +213,20 @@ __metadata:
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.668":
+  version: 1.4.792
+  resolution: "electron-to-chromium@npm:1.4.792"
+  checksum: 10c0/ade79be9394a193030bf9df5119e7255df5a12680f41e5cde55dae072a11b1f86a7a2b449a893c68f2e69f0dbcd95a19f1b3c22f6f6c5f052828aac7591a288f
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "escalade@npm:3.1.2"
+  checksum: 10c0/6b4adafecd0682f3aa1cd1106b8fff30e492c7015b178bc81b2d2f75106dabea6c6d6e8508fc491bd58e597c74abb0e8e2368f943ecb9393d4162e3c2f3cf287
   languageName: node
   linkType: hard
 
@@ -321,10 +356,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-releases@npm:^2.0.14":
+  version: 2.0.14
+  resolution: "node-releases@npm:2.0.14"
+  checksum: 10c0/199fc93773ae70ec9969bc6d5ac5b2bbd6eb986ed1907d751f411fef3ede0e4bfdb45ceb43711f8078bea237b6036db8b1bf208f6ff2b70c7d615afd157f3ab9
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 10c0/666f6973f332f27581371efaf303fd6c272cc43c2057b37aa99e3643158c7e4b2626549555d88626e99ea9e046f82f32e41bbde5f1508547e9a11b149b52387c
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "picocolors@npm:1.0.1"
+  checksum: 10c0/c63cdad2bf812ef0d66c8db29583802355d4ca67b9285d846f390cc15c2f6ccb94e8cb7eb6a6e97fc5990a6d3ad4ae42d86c84d3146e667c739a4234ed50d400
   languageName: node
   linkType: hard
 
@@ -335,12 +384,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.5":
-  version: 3.2.5
-  resolution: "prettier@npm:3.2.5"
+"prettier@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "prettier@npm:3.3.1"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
+  checksum: 10c0/c25a709c9f0be670dc6bcb190b622347e1dbeb6c3e7df8b0711724cb64d8647c60b839937a4df4df18e9cfb556c2b08ca9d24d9645eb5488a7fc032a2c4d5cb3
   languageName: node
   linkType: hard
 
@@ -362,7 +411,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    prettier: "npm:^3.2.5"
+    browserslist: "npm:^4.23.0"
+    prettier: "npm:^3.3.1"
   languageName: unknown
   linkType: soft
 
@@ -415,5 +465,19 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 10c0/02f19e458ec78ead8fffbf711f834ad8ecd2cc6ade4ec0320790713dccc0a412b99e7fd907c4cda2a1dc602c75db6f12e0108e87a5afad4b2f9e90a24cabd5a2
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.0.13":
+  version: 1.0.16
+  resolution: "update-browserslist-db@npm:1.0.16"
+  dependencies:
+    escalade: "npm:^3.1.2"
+    picocolors: "npm:^1.0.1"
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    update-browserslist-db: cli.js
+  checksum: 10c0/5995399fc202adbb51567e4810e146cdf7af630a92cc969365a099150cb00597e425cc14987ca7080b09a4d0cfd2a3de53fbe72eebff171aed7f9bb81f9bf405
   languageName: node
   linkType: hard


### PR DESCRIPTION
This PR updates `browserslist` specification from:
```text
defaults and > 1%, not ie 11, not op_mini all
```

to
```text
defaults and > 1%, last 2 Chrome versions, not dead, not op_mini all
```

Effectively, this only adds the latest Chrome to the list of supported browsers returned by the previous specification (output of `npx browserslist`):
```diff
  and_chr 124
+ chrome 125
  chrome 124
  chrome 123
  chrome 122
  chrome 109
  edge 124
  edge 123
  firefox 124
  ios_saf 17.4
  ios_saf 17.3
  ios_saf 16.6-16.7
  op_mob 80
  safari 17.4
  samsung 24
```

Other than inclusion of the latest Chrome, IMO the change from `not ie 11` to `not dead` is semantically better (and it excludes other dead browsers - like previous IE versions - not just IE 11).

---

In addition to the spec change, this PR also updates NPM dependencies to the latest versions as of June 3, 2024, adds a cleanup script that cleans up `package.json` during `yarn pack` command (to not publish development-only properties), and adds `package.json.md` file with additional documentation for `package.json`.