### PR TITLE
Make "typescript" peer dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "packageManager": "yarn@4.3.1",
   "resolutions": {
-    "@typescript-eslint/scope-manager": "^8.0.0-alpha.58",
-    "@typescript-eslint/type-utils": "^8.0.0-alpha.58",
-    "@typescript-eslint/types": "^8.0.0-alpha.58",
-    "@typescript-eslint/utils": "^8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "^8.0.0-alpha.60",
+    "@typescript-eslint/type-utils": "^8.0.0-alpha.60",
+    "@typescript-eslint/types": "^8.0.0-alpha.60",
+    "@typescript-eslint/utils": "^8.0.0-alpha.60"
   },
   "devDependencies": {
     "@pandell/eslint-config": "workspace:packages/eslint-config",

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,16 +9,16 @@ Add the following to your `package.json`:
 ```jsonc
 {
   "devDependencies": {
-    "@pandell/eslint-config": "^9.0.0",
-    "eslint": "^9.5.0",
+    "@pandell/eslint-config": "^9.0.1",
+    "eslint": "^9.8.0",
     "eslint-plugin-testing-library": "^6.2.2", // see note 1 below
     // ...
   },
   "resolutions": { // see note below
-    "@typescript-eslint/scope-manager": "^8.0.0-alpha.58",
-    "@typescript-eslint/type-utils": "^8.0.0-alpha.58",
-    "@typescript-eslint/types": "^8.0.0-alpha.58",
-    "@typescript-eslint/utils": "^8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "^8.0.0-alpha.60",
+    "@typescript-eslint/type-utils": "^8.0.0-alpha.60",
+    "@typescript-eslint/types": "^8.0.0-alpha.60",
+    "@typescript-eslint/utils": "^8.0.0-alpha.60"
   },
   // ...
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,12 +32,12 @@
     "@types/eslint__js": "^8.42.3",
     "eslint-plugin-import-x": "^3.1.0",
     "eslint-plugin-jest-dom": "^5.4.0",
-    "eslint-plugin-jsdoc": "^48.9.2",
-    "eslint-plugin-react-hooks": "^5.1.0-rc-941e1b4a-20240729",
+    "eslint-plugin-jsdoc": "^48.10.2",
+    "eslint-plugin-react-hooks": "^5.1.0-rc-3208e73e-20240730",
     "eslint-plugin-react-refresh": "^0.4.9",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-vitest": "^0.5.4",
-    "typescript-eslint": "^8.0.0-alpha.58"
+    "typescript-eslint": "^8.0.0-alpha.60"
   },
   "devDependencies": {
     "eslint": "^9.8.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/eslint-config",
   "type": "module",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Pandell ESLint shared config",
   "keywords": [
     "eslint",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -51,6 +51,9 @@
   "peerDependenciesMeta": {
     "eslint-plugin-testing-library": {
       "optional": true
+    },
+    "typescript": {
+      "optional": true
     }
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,13 +278,13 @@ __metadata:
     eslint: "npm:^9.8.0"
     eslint-plugin-import-x: "npm:^3.1.0"
     eslint-plugin-jest-dom: "npm:^5.4.0"
-    eslint-plugin-jsdoc: "npm:^48.9.2"
-    eslint-plugin-react-hooks: "npm:^5.1.0-rc-941e1b4a-20240729"
+    eslint-plugin-jsdoc: "npm:^48.10.2"
+    eslint-plugin-react-hooks: "npm:^5.1.0-rc-3208e73e-20240730"
     eslint-plugin-react-refresh: "npm:^0.4.9"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     eslint-plugin-vitest: "npm:^0.5.4"
     typescript: "npm:^5.5.4"
-    typescript-eslint: "npm:^8.0.0-alpha.58"
+    typescript-eslint: "npm:^8.0.0-alpha.60"
   peerDependencies:
     eslint: ">= 9"
     eslint-plugin-testing-library: ">= 6"
@@ -381,15 +381,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.58"
+"@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.60"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/type-utils": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/type-utils": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.60"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -400,66 +400,66 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/d452e601b146c9c7a04115614482ae977eebbf462097c91beff79dfc53bcb0bf22cb5a2d8cd975c6d9bc09f763e73fec13ce57b7f0a27231a79cbbab4a4c3d5a
+  checksum: 10c0/bd142cf4d8dc86b87b59cbed6fdde6c7dfb10e91b000ca44ffae613bc796d0b38028b4788a07b50fad13a742bafc8b8dfceb404e6c89c3cca78b0dea03d67efb
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/parser@npm:8.0.0-alpha.58"
+"@typescript-eslint/parser@npm:8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/parser@npm:8.0.0-alpha.60"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.60"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/b6321c3291c7f8c018d3cbe13ea5ace81b6193a7415e693b9c92069ed5f0e6a6e0b1fee75216d90895fdd34e12d0ea7e2f10add900e5a744b0b9bdc31d48a961
+  checksum: 10c0/ab1c61933af694ae2c0d1977f86ca79c859405ce5d1e62a33e37148988574bb13d3e2e7777b85d8f9d8632c41b95d29bb98b52dad7251d7939205650a57c8ab1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:^8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/scope-manager@npm:8.0.0-alpha.58"
+"@typescript-eslint/scope-manager@npm:^8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/scope-manager@npm:8.0.0-alpha.60"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
-  checksum: 10c0/600154aa3f87b8f060bffb3e4b92765ee637a2d6abfae9ea2e2e4b8e0bc88a9aed0f0304e6b52ad66cb11c83ed68cc365969349b69b6daa503c050d9e9fb4b95
+    "@typescript-eslint/types": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.60"
+  checksum: 10c0/9ebd6065ac239fa4071db8c49a2ba3441461ec25a29520b9b087d214e27437331e92a30543ee6c237f874ef55c9b34ca303512ed247114e56c8e584746c01481
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:^8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/type-utils@npm:8.0.0-alpha.58"
+"@typescript-eslint/type-utils@npm:^8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/type-utils@npm:8.0.0-alpha.60"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.60"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/739e5d9b3a5ed92eae1605869a421b81e0f3efdcca91b275050a307ba805a28f245831223ab0125694da8fc9d881b2baceda2931985ad97d0d11703e717ab474
+  checksum: 10c0/d1fec551e869b618796f7a185504596505080657ee3458db20dc4e3ce8ca078680c12aa54447e369602538730228cac3fdf0a216ecdd9a2d2a18947f2b040daf
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:^8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/types@npm:8.0.0-alpha.58"
-  checksum: 10c0/5e69fbdb54244e111f00000636e02dc16556739e846086d22a12bec75907e4f8b92d2e97141a7aeb35d7426aab3a12515e39200ecf464373a721bddf34f6bae6
+"@typescript-eslint/types@npm:^8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/types@npm:8.0.0-alpha.60"
+  checksum: 10c0/321346c9466c138fe73e453a3d3b8579f110725cc84ccec5c40a9de1449e3a962abe53763fcd796f44cf072aa76236902dbc20df998ac926d3bf4e588f381bff
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0-alpha.58"
+"@typescript-eslint/typescript-estree@npm:8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0-alpha.60"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.60"
     debug: "npm:^4.3.4"
     globby: "npm:^11.1.0"
     is-glob: "npm:^4.0.3"
@@ -469,31 +469,31 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/b9b11a8c6e5d51b31480f275b6ff3b06c547a67b9b235d61456286d0cc1bee5e19e86ed0cef4d9e63cd9cc1b0a4322dc342fb32c7f5ce29a0fb987d35d659de0
+  checksum: 10c0/9fec7ee2458cfbeceaf29d9fe9464dae1e852dcf9a249ad5d3b7764fc23da24386d3431a8bbc769bb3e0c61e36f9173a1061e7cc55b0007b79efb8e59d4d5413
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/utils@npm:8.0.0-alpha.58"
+"@typescript-eslint/utils@npm:^8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/utils@npm:8.0.0-alpha.60"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.60"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/a2f148dbcff1518253e3256219e2ba87d65514b9b8be2d7c111121d0071a590b29c177773a0c9bb4332666b990870c7e7aefe9c0f3a28df5d781f6452210443e
+  checksum: 10c0/fa11ffd00a37f2c43f3d596d813848eba243abf5ea95dbdce5e5e1e9895e530dda0bd8b166061bb1bc5b7f9ddd752bd8d3dde80439f97e153f57f47079db821d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0-alpha.58"
+"@typescript-eslint/visitor-keys@npm:8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0-alpha.60"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.60"
     eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10c0/f1c208dcb7dad078e5cfbeac8a5f0473418b24b2715a5f3ff4415944319821391c2cdd73bad2aebdc3c70716085f84b15e9ad8f253ad96e50533ea37bbd8c467
+  checksum: 10c0/e0ca99ddd00a35a264c17d0c7d4c175139e664fd97ffab8a398778a6b978c4ed6f603868501252518d7db8114483684eabc169b2780926ed10bf385b899263eb
   languageName: node
   linkType: hard
 
@@ -621,9 +621,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001640":
-  version: 1.0.30001643
-  resolution: "caniuse-lite@npm:1.0.30001643"
-  checksum: 10c0/7fcd0fd180bbe6764311ad57b0d39c23afdcc3bb1d8f804e7a76752c62a85b1bb7cf74b672d9da2f0afe7ad75336ff811a6fe279eb2a54bc04c272b6b62e57f1
+  version: 1.0.30001644
+  resolution: "caniuse-lite@npm:1.0.30001644"
+  checksum: 10c0/96de82909f3ba9f44e5b261c42d3d8814ba99b7b8b48eb8f8eafb7015804ccb2bc2120c5fbc5e193e14e0c87bf1cd0d4de920d8f5a5b477e66e8f0c3972d0eb7
   languageName: node
   linkType: hard
 
@@ -799,15 +799,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^48.9.2":
-  version: 48.9.2
-  resolution: "eslint-plugin-jsdoc@npm:48.9.2"
+"eslint-plugin-jsdoc@npm:^48.10.2":
+  version: 48.10.2
+  resolution: "eslint-plugin-jsdoc@npm:48.10.2"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.46.0"
     are-docs-informative: "npm:^0.0.2"
     comment-parser: "npm:1.4.1"
     debug: "npm:^4.3.5"
     escape-string-regexp: "npm:^4.0.0"
+    espree: "npm:^10.1.0"
     esquery: "npm:^1.6.0"
     parse-imports: "npm:^2.1.1"
     semver: "npm:^7.6.3"
@@ -815,7 +816,7 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/efcc8dbd0d2f1374682e97f08e1bcfe77109cb0f6b82862bcf389d3a60a2374fecbfb0a060bb1977228856f973e1bb6cac1f2bbfd95e2a9dd43f81daf9f191c1
+  checksum: 10c0/b0954db45fc087b36b984f550236a7c2d8386bf3bc57477f2c95c24a612922bb81b1ffee598226b5004e50890e2e6fada33432db38111a0c40bdbc759614382e
   languageName: node
   linkType: hard
 
@@ -902,7 +903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^5.1.0-rc-941e1b4a-20240729":
+"eslint-plugin-react-hooks@npm:^5.1.0-rc-3208e73e-20240730":
   version: 5.1.0-rc-fb9a90fa48-20240614
   resolution: "eslint-plugin-react-hooks@npm:5.1.0-rc-fb9a90fa48-20240614"
   peerDependencies:
@@ -1916,17 +1917,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "typescript-eslint@npm:8.0.0-alpha.58"
+"typescript-eslint@npm:^8.0.0-alpha.60":
+  version: 8.0.0-alpha.60
+  resolution: "typescript-eslint@npm:8.0.0-alpha.60"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/parser": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/eslint-plugin": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/parser": "npm:8.0.0-alpha.60"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.60"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/5be05a22ccc95ca2ae6c10a5521ca735542d07182e29e6b8e3a8e37a25a231145045d1eaa3e01737c96013f3376d786d2c2653dea936b2d80a911c5551214a3f
+  checksum: 10c0/05d9e10e9145b5321473d473c480a5a08a7bde0ec0bd90bbe904bbacf8ba4d55e20638158c92a4e332851f2dc424422f13ada96eb79e98ebab144742c3ca2ef8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,8 @@ __metadata:
   peerDependenciesMeta:
     eslint-plugin-testing-library:
       optional: true
+    typescript:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
TypeScript dependency is not needed when using `@pandell/eslint-config` in JavaScript-only projects.