### PR TITLE
Switch to "eslint-plugin-testing-library" flat config + NPM update 2024-08-14

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
   },
   "packageManager": "yarn@4.4.0",
   "resolutions": {
-    "@typescript-eslint/type-utils": "^8.0.1",
-    "@typescript-eslint/utils": "^8.0.1"
+    "@typescript-eslint/type-utils": "^8.1.0",
+    "@typescript-eslint/utils": "^8.1.0"
   },
   "devDependencies": {
     "@pandell/eslint-config": "workspace:packages/eslint-config",
     "browserslist": "^4.23.3",
-    "eslint": "^9.8.0",
+    "eslint": "^9.9.0",
     "prettier": "^3.3.3",
     "typescript": "^5.5.4"
   },

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,14 +9,14 @@ Add the following to your `package.json`:
 ```jsonc
 {
   "devDependencies": {
-    "@pandell/eslint-config": "^9.1.1",
-    "eslint": "^9.8.0",
-    "eslint-plugin-testing-library": "^6.2.2", // see note 1 below
+    "@pandell/eslint-config": "^9.2.0",
+    "eslint": "^9.9.0",
+    "eslint-plugin-testing-library": "^6.3.0", // see note 1 below
     // ...
   },
   "resolutions": { // see note below
-    "@typescript-eslint/type-utils": "^8.0.1",
-    "@typescript-eslint/utils": "^8.0.1"
+    "@typescript-eslint/type-utils": "^8.1.0",
+    "@typescript-eslint/utils": "^8.1.0"
   },
   // ...
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/eslint-config",
   "type": "module",
-  "version": "9.1.1",
+  "version": "9.2.0",
   "description": "Pandell ESLint shared config",
   "keywords": [
     "eslint",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,27 +25,27 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.9.0",
+    "@eslint-react/eslint-plugin": "^1.10.1",
     "@eslint/compat": "^1.1.1",
-    "@eslint/js": "^9.8.0",
+    "@eslint/js": "^9.9.0",
     "@tanstack/eslint-plugin-query": "^5.51.15",
     "@types/eslint__js": "^8.42.3",
     "eslint-plugin-import-x": "^3.1.0",
     "eslint-plugin-jest-dom": "^5.4.0",
-    "eslint-plugin-jsdoc": "^50.0.0",
-    "eslint-plugin-react-hooks": "^5.1.0-rc-e948a5ac-20240807",
+    "eslint-plugin-jsdoc": "^50.2.2",
+    "eslint-plugin-react-hooks": "^5.1.0-rc-49496d49-20240814",
     "eslint-plugin-react-refresh": "^0.4.9",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-vitest": "^0.5.4",
-    "typescript-eslint": "^8.0.1"
+    "typescript-eslint": "^8.1.0"
   },
   "devDependencies": {
-    "eslint": "^9.8.0",
+    "eslint": "^9.9.0",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
     "eslint": ">= 9",
-    "eslint-plugin-testing-library": ">= 6",
+    "eslint-plugin-testing-library": ">= 6.3.0",
     "typescript": ">= 5"
   },
   "peerDependenciesMeta": {

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -311,6 +311,7 @@ async function createPandellTestingConfig(
     enabledVitest ? import("eslint-plugin-vitest") : null,
   ]);
   if (jsDom && testingLibrary && testingLibraryCompat) {
+    const testingLibraryReactFlatConfig = testingLibrary.default.configs["flat/react"];
     configs.push(
       {
         ...jsDom.default.configs["flat/recommended"],
@@ -318,14 +319,16 @@ async function createPandellTestingConfig(
         files: resolvedFiles,
       },
       {
+        ...testingLibraryReactFlatConfig,
         name: "eslint-plugin-testing-library/react",
         // 2024-06-15, milang: eslint-plugin-testing-library currently does not support
-        // either flat config or ESLint 9 API; we have to use an adapter for the time being, see
+        // ESLint 9 API; we have to use an adapter for the time being, see
         // https://github.com/testing-library/eslint-plugin-testing-library/issues/899#issuecomment-2121272355
         plugins: {
-          "testing-library": testingLibraryCompat.fixupPluginRules(testingLibrary.default),
+          "testing-library": testingLibraryCompat.fixupPluginRules(
+            testingLibraryReactFlatConfig.plugins!["testing-library"],
+          ),
         },
-        rules: testingLibrary.default.configs.react.rules,
         files: resolvedFiles,
       },
     );

--- a/packages/eslint-config/typings/testing.d.ts
+++ b/packages/eslint-config/typings/testing.d.ts
@@ -10,6 +10,11 @@ declare module "eslint-plugin-testing-library" {
       react: Linter.Config;
       vue: Linter.Config;
       marko: Linter.Config;
+      ["flat/dom"]: Linter.FlatConfig;
+      ["flat/angular"]: Linter.FlatConfig;
+      ["flat/react"]: Linter.FlatConfig;
+      ["flat/vue"]: Linter.FlatConfig;
+      ["flat/marko"]: Linter.FlatConfig;
     };
     rules: ESLint.Plugin["rules"];
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,14 +14,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@es-joy/jsdoccomment@npm:~0.46.0":
-  version: 0.46.0
-  resolution: "@es-joy/jsdoccomment@npm:0.46.0"
+"@es-joy/jsdoccomment@npm:~0.48.0":
+  version: 0.48.0
+  resolution: "@es-joy/jsdoccomment@npm:0.48.0"
   dependencies:
     comment-parser: "npm:1.4.1"
     esquery: "npm:^1.6.0"
-    jsdoc-type-pratt-parser: "npm:~4.0.0"
-  checksum: 10c0/a7a67936ebf6d9aaf74af018c3ac744769af3552b05ad9b88fca96b2ffdca16e724b0ff497f53634ec4cca81e98d8c471b6b6bde0fa5b725af4222ad9a0707f0
+    jsdoc-type-pratt-parser: "npm:~4.1.0"
+  checksum: 10c0/8d87c7c0426fade009c30ab429d4ede53fd253d40b55079c02bdacdaa4c0fe904aaea5e3084cd98052f2bed6b3030c381d84f4a3251b343a71fee6f681a08bee
   languageName: node
   linkType: hard
 
@@ -43,63 +43,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/ast@npm:1.9.0"
+"@eslint-react/ast@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/ast@npm:1.10.1"
   dependencies:
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/typescript-estree": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    "@typescript-eslint/visitor-keys": "npm:8.0.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/typescript-estree": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
     birecord: "npm:^0.1.1"
-    remeda: "npm:^2.7.1"
     string-ts: "npm:^2.2.0"
-    ts-pattern: "npm:^5.2.0"
-  checksum: 10c0/37fe8bb354c2fdb7f8f8915d536f7c1d83d5871177d1a6310e4d0e69ce968081cd9386767ee80f16b6e576fec3177048ce4160f4e6b62ddd61fce6f79bbe840f
+    ts-pattern: "npm:^5.3.1"
+  checksum: 10c0/cfb7231cef3d153e0b8ae3f3a2efc3932cca507102cb55388adda1e805389843dc485c3679de84786b9371178f36a8ebf4d18d1ad71cbce0c413166e54df54b7
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/core@npm:1.9.0"
+"@eslint-react/core@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/core@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/jsx": "npm:1.9.0"
-    "@eslint-react/shared": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@eslint-react/var": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/type-utils": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/jsx": "npm:1.10.1"
+    "@eslint-react/shared": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@eslint-react/var": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/type-utils": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
     short-unique-id: "npm:^5.2.0"
-    ts-pattern: "npm:^5.2.0"
-  checksum: 10c0/635b0b3683c664ad687f5576796b0226e7eb63de26878e9a03365bcd0516b085d2689fdbc2ccf5fa82092c38f9fff10203f21363d887a060aa4888f84cd99c00
+    ts-pattern: "npm:^5.3.1"
+  checksum: 10c0/a0dfba896feb5f607340f588956d4ac8943265b79b68086c79bc47cd2c3c8ee82d59b2b9b5e7b80de1ddeeec3748e8b8d2346c253794745d3fbb324f7efad63b
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/eslint-plugin@npm:1.9.0"
+"@eslint-react/eslint-plugin@npm:^1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/eslint-plugin@npm:1.10.1"
   dependencies:
-    "@eslint-react/shared": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/type-utils": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    eslint-plugin-react-debug: "npm:1.9.0"
-    eslint-plugin-react-dom: "npm:1.9.0"
-    eslint-plugin-react-hooks-extra: "npm:1.9.0"
-    eslint-plugin-react-naming-convention: "npm:1.9.0"
-    eslint-plugin-react-x: "npm:1.9.0"
-    remeda: "npm:^2.7.1"
+    "@eslint-react/shared": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/type-utils": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+    eslint-plugin-react-debug: "npm:1.10.1"
+    eslint-plugin-react-dom: "npm:1.10.1"
+    eslint-plugin-react-hooks-extra: "npm:1.10.1"
+    eslint-plugin-react-naming-convention: "npm:1.10.1"
+    eslint-plugin-react-x: "npm:1.10.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -108,68 +103,67 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/4ca5a4d0c6181c9211f16973808052b7748021bc3ac3641ae77b0b5f74ec36b7f4d49ab085b25ea25cf63448e11c3c880ca04e86e51393a636a67d1a3c47f7dc
+  checksum: 10c0/12d94c09c1595ad19a9209df07669063154f3a22abce339f887af859bec520b460bb1a3afc2d60ef03093fa63d969f5d4ab4547b279154684c55b1df43ad84af
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/jsx@npm:1.9.0"
+"@eslint-react/jsx@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/jsx@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@eslint-react/var": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
-    ts-pattern: "npm:^5.2.0"
-  checksum: 10c0/6c525b889bff1db91884bb24aadee27f3caa8f10dad06055a3dfda7e84e6aa438795a2299b46c1a59a8ad40a13668297005202f0ff36ce99ffdb173e0518a2fb
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@eslint-react/var": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+    ts-pattern: "npm:^5.3.1"
+  checksum: 10c0/90cc80fa5c1ae8715fe35ff5fc5b0d0787b4d28ba8fc775516f2279a725746cea634778dc6b79a0a3c49acc43f920534acc735f2fb5a727e7dbe4c8660957c0b
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/shared@npm:1.9.0"
+"@eslint-react/shared@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/shared@npm:1.10.1"
   dependencies:
-    "@typescript-eslint/utils": "npm:^8.0.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@typescript-eslint/utils": "npm:^8.1.0"
     picomatch: "npm:^4.0.2"
-  checksum: 10c0/6540b9408eb983c88397a698574f9ec426a6762003a6740c04ad8361f8ca8a99706e599c0061cbb2bd7da783cd7086f1668af19d6b14d8c9e5b3cc0ebfe0c931
+  checksum: 10c0/8e5a5fc47ee8dd7c40123805838bcbf2a635a1a901a8e1e3f9fe42cc7cc379f6e0b5950f21788302458ad0c73b907c9695080c830755ecfbb944e5dbac7dbbfb
   languageName: node
   linkType: hard
 
-"@eslint-react/tools@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/tools@npm:1.9.0"
-  checksum: 10c0/1c33ff5954d28a493adb245ad6ff1a05bc87f22923e1191aa196431fe3a3ede00370d08771010076d76c1aa56cede70bd0dc8397cd3431cc302136de26b762f8
+"@eslint-react/tools@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/tools@npm:1.10.1"
+  checksum: 10c0/23c4e56abe7286bfb8e77c25ca4c5cf59a1f7306b4a04940d44e249d8b10415b2c4d2d431536aa05d603c7c456e7deb3f6d6e0fe3bd6247d184e2c445988b934
   languageName: node
   linkType: hard
 
-"@eslint-react/types@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/types@npm:1.9.0"
+"@eslint-react/types@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/types@npm:1.10.1"
   dependencies:
-    "@eslint-react/tools": "npm:1.9.0"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
-  checksum: 10c0/b396c13b7846e6970293d73468196246a145b8d8ea95b81fa001e0b236cbdb7120a29fdd98243478fa944258320861bf51ca0d5cbb9986b90a11cdad80c827fc
+    "@eslint-react/tools": "npm:1.10.1"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+  checksum: 10c0/40911f65fa1fc660caeaf69f581c34aa1baa24f0d98884ebf84aea8a23729aabf834de0ca933fed56a1dbabcd2e9a380e21fd3054dfe9d0f1dd0f68f8f52f43a
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@eslint-react/var@npm:1.9.0"
+"@eslint-react/var@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@eslint-react/var@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
-  checksum: 10c0/7f206765552f10383bc494dcb1191c9c1e9aa50354b0262d86acdf26e2b30ee74da82127cf4a11aa3b0630bc34a2297f0f25292997b1a612ec138b77c24ec157
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+    ts-pattern: "npm:^5.3.1"
+  checksum: 10c0/e0dd43b2ddad43a9a77d75db23d008d044e82ee833c170e5d0711b09d9ac4b2c13b7b7ab7423f3f9798e869ce0d9e1fc131dc3ebef6042303678f40195cf5f65
   languageName: node
   linkType: hard
 
@@ -208,10 +202,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.8.0, @eslint/js@npm:^9.8.0":
-  version: 9.8.0
-  resolution: "@eslint/js@npm:9.8.0"
-  checksum: 10c0/42edaae6b020436410454579509dcb6a8cd5b260e9f18e037fd803ae28d35eb13663d4019f0ab8ba686a19d3c4a43b0e11394c148e23345377ab694da0e83262
+"@eslint/js@npm:9.9.0, @eslint/js@npm:^9.9.0":
+  version: 9.9.0
+  resolution: "@eslint/js@npm:9.9.0"
+  checksum: 10c0/6ec9f1f0d576132444d6a5c66a8a08b0be9444e3ebb563fa6a6bebcf5299df3da7e454dc04c0fa601bb811197f00764b3a04430d8458cdb8e3a4677993d23f30
   languageName: node
   linkType: hard
 
@@ -273,24 +267,24 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.9.0"
+    "@eslint-react/eslint-plugin": "npm:^1.10.1"
     "@eslint/compat": "npm:^1.1.1"
-    "@eslint/js": "npm:^9.8.0"
+    "@eslint/js": "npm:^9.9.0"
     "@tanstack/eslint-plugin-query": "npm:^5.51.15"
     "@types/eslint__js": "npm:^8.42.3"
-    eslint: "npm:^9.8.0"
+    eslint: "npm:^9.9.0"
     eslint-plugin-import-x: "npm:^3.1.0"
     eslint-plugin-jest-dom: "npm:^5.4.0"
-    eslint-plugin-jsdoc: "npm:^50.0.0"
-    eslint-plugin-react-hooks: "npm:^5.1.0-rc-e948a5ac-20240807"
+    eslint-plugin-jsdoc: "npm:^50.2.2"
+    eslint-plugin-react-hooks: "npm:^5.1.0-rc-49496d49-20240814"
     eslint-plugin-react-refresh: "npm:^0.4.9"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     eslint-plugin-vitest: "npm:^0.5.4"
     typescript: "npm:^5.5.4"
-    typescript-eslint: "npm:^8.0.1"
+    typescript-eslint: "npm:^8.1.0"
   peerDependencies:
     eslint: ">= 9"
-    eslint-plugin-testing-library: ">= 6"
+    eslint-plugin-testing-library: ">= 6.3.0"
     typescript: ">= 5"
   peerDependenciesMeta:
     eslint-plugin-testing-library:
@@ -384,15 +378,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.0.1"
+"@typescript-eslint/eslint-plugin@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.1.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.1"
-    "@typescript-eslint/type-utils": "npm:8.0.1"
-    "@typescript-eslint/utils": "npm:8.0.1"
-    "@typescript-eslint/visitor-keys": "npm:8.0.1"
+    "@typescript-eslint/scope-manager": "npm:8.1.0"
+    "@typescript-eslint/type-utils": "npm:8.1.0"
+    "@typescript-eslint/utils": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -403,66 +397,66 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/fd4e11599c4a85d0fbbd0be350f11acaa32d424bc5c2c0b672133266b4b56fc20a78edd0c7b803b4223a1a66736624561a60fee827738118550733d14afb775a
+  checksum: 10c0/7bbeae588f859b59c34d6a76cac06ef0fa605921b40c5d3b65b94829984280ea84c4dd3f5cb9ce2eb326f5563e9abb4c90ebff05c47f83f4def296c2ea1fa86c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/parser@npm:8.0.1"
+"@typescript-eslint/parser@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/parser@npm:8.1.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.0.1"
-    "@typescript-eslint/types": "npm:8.0.1"
-    "@typescript-eslint/typescript-estree": "npm:8.0.1"
-    "@typescript-eslint/visitor-keys": "npm:8.0.1"
+    "@typescript-eslint/scope-manager": "npm:8.1.0"
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/typescript-estree": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/bf93640f06c9d2e09a79d015d2c3303f58a8569a3f6928544feeeaad8825388133b5e44ca017b4480d38c037644cf6390c785129539fe256f55422ae608943b5
+  checksum: 10c0/b94b2d3ab5ca505484d100701fad6a04a5dc8d595029bac1b9f5b8a4a91d80fd605b0f65d230b36a97ab7e5d55eeb0c28af2ab63929a3e4ab8fdefd2a548c36b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.0.1, @typescript-eslint/scope-manager@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.0.1"
+"@typescript-eslint/scope-manager@npm:8.1.0, @typescript-eslint/scope-manager@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.1.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.1"
-    "@typescript-eslint/visitor-keys": "npm:8.0.1"
-  checksum: 10c0/79c00bc726c0c14b800bbbc1c1b88978c2cbeb29d2b06b94a5773f959aafac5cfb37bdb8c3bb80b9fb07fd10440413fce9098f338dce100696a4d3dc1ea6b187
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
+  checksum: 10c0/2bcf8cd176a1819bddcae16c572e7da8fba821b995a91cd53d64d8d6b85a17f5a895522f281ba57e34929574bddd4d6684ee3e545ec4e8096be4c3198e253a9a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/type-utils@npm:8.0.1"
+"@typescript-eslint/type-utils@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/type-utils@npm:8.1.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.0.1"
-    "@typescript-eslint/utils": "npm:8.0.1"
+    "@typescript-eslint/typescript-estree": "npm:8.1.0"
+    "@typescript-eslint/utils": "npm:8.1.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/5cbf604044d5cd9cc6e95a2eee5a62803a09f46ccf4aa7293e373a4be8b7b57b470cbc97c1121ef354f842e7fc1d17b30c81bf3540023382ad5e339c9ca3ce15
+  checksum: 10c0/62753941c4136e8d2daa72fe0410dea48e5317a6f12ece6382ca85e29912bd1b3f739b61d1060fc0a1f8c488dfc905beab4c8b8497951a21c3138a659c7271ec
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.0.1, @typescript-eslint/types@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/types@npm:8.0.1"
-  checksum: 10c0/e7c02d4e153a935c04bfddc0c8fc1618b1c8e9767583cff05a0e063bbacb7f3c8fac2257879c41162fe19094a0de3a567b57969177b2a0c32f39accd4c5601d5
+"@typescript-eslint/types@npm:8.1.0, @typescript-eslint/types@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/types@npm:8.1.0"
+  checksum: 10c0/ceade44455f45974e68956016c4d1c6626580732f7f9675e14ffa63db80b551752b0df596b20473dae9f0dc6ed966e17417dc2cf36e1a82b6ab0edc97c5eaa50
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.0.1, @typescript-eslint/typescript-estree@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.0.1"
+"@typescript-eslint/typescript-estree@npm:8.1.0, @typescript-eslint/typescript-estree@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.1.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.1"
-    "@typescript-eslint/visitor-keys": "npm:8.0.1"
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
     debug: "npm:^4.3.4"
     globby: "npm:^11.1.0"
     is-glob: "npm:^4.0.3"
@@ -472,31 +466,31 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/12507995dc634a1746b581635e0df9f986ad01e7f0b4482f1f240986e7277ebd301dfe3b59c07da6d1f3d465f9110dc2a61ce50b67a8f31188cad13f7cc3632e
+  checksum: 10c0/a7bc8275df1c79c4cb14ef086c56674316dd4907efec53eddca35d0b5220428b69c82178ce2d95138da2e398269c8bd0764cae8020a36417e411e35c3c47bc4b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/utils@npm:8.0.1"
+"@typescript-eslint/utils@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/utils@npm:8.1.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.1"
-    "@typescript-eslint/types": "npm:8.0.1"
-    "@typescript-eslint/typescript-estree": "npm:8.0.1"
+    "@typescript-eslint/scope-manager": "npm:8.1.0"
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/typescript-estree": "npm:8.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/9ab4baee82ac74caee18fb687697698043385aea5d0ec4bb34d874a6969eaa3e48f9319ab023cbcb6114f86de17f7360a43460fb4159c61760a2d2984004dd21
+  checksum: 10c0/c95503a6bdcd98b1ff04d1adbf46377b2036b1c510d90a4a056401f996f775f06c3108c95fb81cd6babc9c97b73b91b8e848f0337bc508de8a49c993582f0e75
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.0.1":
-  version: 8.0.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.0.1"
+"@typescript-eslint/visitor-keys@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.1.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.1"
+    "@typescript-eslint/types": "npm:8.1.0"
     eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10c0/64c12095a97808bb1e1f5709192b274cac58d6b8fbbf9ec8fafead30f7effef7f0232244ec759298d046e1cd43521b9f3ba37b80618d5184c8b22fae665a7068
+  checksum: 10c0/b7544dbb0eec1ddbfcd95c04b51b9a739c2e768c16d1c88508f976a2b0d1bc02fefb7491930e06e48073a5c07c6f488cd8403bba3a8b918888b93a88d5ac3869
   languageName: node
   linkType: hard
 
@@ -631,9 +625,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001650
-  resolution: "caniuse-lite@npm:1.0.30001650"
-  checksum: 10c0/81d271517f452321d4274d514dcbf4d57fc7ca6d2f82d4e273a850fc6d92d334d97bbec8359ce2237c7f2d128729037b82ca506c7213511dc8380b8ec24d9d45
+  version: 1.0.30001651
+  resolution: "caniuse-lite@npm:1.0.30001651"
+  checksum: 10c0/7821278952a6dbd17358e5d08083d258f092e2a530f5bc1840657cb140fbbc5ec44293bc888258c44a18a9570cde149ed05819ac8320b9710cf22f699891e6ad
   languageName: node
   linkType: hard
 
@@ -697,7 +691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5":
+"debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6":
   version: 4.3.6
   resolution: "debug@npm:4.3.6"
   dependencies:
@@ -735,9 +729,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.4":
-  version: 1.5.5
-  resolution: "electron-to-chromium@npm:1.5.5"
-  checksum: 10c0/6e5e12f729a74a78d9a7386ea32039262cb8a2f4611ab346da1f162c270d0569194c72169042080a1017220835ed30ee2d77ca5ba13c1acaa5fa0d373fbc0ad5
+  version: 1.5.8
+  resolution: "electron-to-chromium@npm:1.5.8"
+  checksum: 10c0/801de2afa0479ffa0cd0e36b7865241dcd3a66a92fca28457431d2dc2bd9c2d066ab07578b419426c504df196f078c63283ee47140c28039d224ec2631acbcee
   languageName: node
   linkType: hard
 
@@ -809,14 +803,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.0.0":
-  version: 50.0.0
-  resolution: "eslint-plugin-jsdoc@npm:50.0.0"
+"eslint-plugin-jsdoc@npm:^50.2.2":
+  version: 50.2.2
+  resolution: "eslint-plugin-jsdoc@npm:50.2.2"
   dependencies:
-    "@es-joy/jsdoccomment": "npm:~0.46.0"
+    "@es-joy/jsdoccomment": "npm:~0.48.0"
     are-docs-informative: "npm:^0.0.2"
     comment-parser: "npm:1.4.1"
-    debug: "npm:^4.3.5"
+    debug: "npm:^4.3.6"
     escape-string-regexp: "npm:^4.0.0"
     espree: "npm:^10.1.0"
     esquery: "npm:^1.6.0"
@@ -826,26 +820,27 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/1d476eabdf604f4a07ef9a22fb7b13ba898d0aed81b2c428d4b6aea766b908ebdc7e6e82a16bac3f83e1013c6edba6d9a15a4015cab9a94c584ebccbd7255b70
+  checksum: 10c0/f41d30246f6a4b6acb55e8cd75cf4fc256315e141ab25f7740fa6fa58cdd24e08cb672b4a350da93aeb126d210bd25981310a50f97cfb108f6a7ce8668b6b90a
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.9.0":
-  version: 1.9.0
-  resolution: "eslint-plugin-react-debug@npm:1.9.0"
+"eslint-plugin-react-debug@npm:1.10.1":
+  version: 1.10.1
+  resolution: "eslint-plugin-react-debug@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/core": "npm:1.9.0"
-    "@eslint-react/jsx": "npm:1.9.0"
-    "@eslint-react/shared": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/type-utils": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/core": "npm:1.10.1"
+    "@eslint-react/jsx": "npm:1.10.1"
+    "@eslint-react/shared": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@eslint-react/var": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/type-utils": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
     string-ts: "npm:^2.2.0"
+    ts-pattern: "npm:^5.3.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -854,25 +849,25 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/e302d9cd36ad9c8a2334737695c713d7b66528dd62e948d3ab06a389bb7c0e8e028a257ffc95029a29420d3ffbafde7723ced94c3555e560db2b7150510896b8
+  checksum: 10c0/34f50ababa6f630b1412abe1d5b57fe9c4e46160041a99748f5e58f444eeaf3d5be2885219a16e66b7e6b4d7fcea5ee9d95c4fd01c09aadf38e147869ac387fd
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.9.0":
-  version: 1.9.0
-  resolution: "eslint-plugin-react-dom@npm:1.9.0"
+"eslint-plugin-react-dom@npm:1.10.1":
+  version: 1.10.1
+  resolution: "eslint-plugin-react-dom@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/core": "npm:1.9.0"
-    "@eslint-react/jsx": "npm:1.9.0"
-    "@eslint-react/shared": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@eslint-react/var": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/core": "npm:1.10.1"
+    "@eslint-react/jsx": "npm:1.10.1"
+    "@eslint-react/shared": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@eslint-react/var": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+    ts-pattern: "npm:^5.3.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -881,26 +876,26 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/44c0251268cdef81fc91b2e97f28cdc7121fa246da53b35d23892e3ef4a3e324d4b47627d5437f6364b56d5ef9b6c2acb05b967a95ffcc9f76f164a0a5cb50a7
+  checksum: 10c0/3a4de4a327cf3b9511664eb993e863ce392f07419f247e868f41ad4528c914cff797f45a4fe743f7c3145aa87b11b63d3b1b4beb45a38aae71507eaf4b573f6c
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.9.0":
-  version: 1.9.0
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.9.0"
+"eslint-plugin-react-hooks-extra@npm:1.10.1":
+  version: 1.10.1
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/core": "npm:1.9.0"
-    "@eslint-react/jsx": "npm:1.9.0"
-    "@eslint-react/shared": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@eslint-react/var": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/type-utils": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/core": "npm:1.10.1"
+    "@eslint-react/jsx": "npm:1.10.1"
+    "@eslint-react/shared": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@eslint-react/var": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/type-utils": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+    ts-pattern: "npm:^5.3.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -909,11 +904,11 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/85cd02e193ec650274beb4cc58263774ded5e7b93393a0b40cfb3bcc177d002c7d6c8d67c279282e477a61136e3662cd36a1cd8e903f342ab94b8083a3c116cd
+  checksum: 10c0/4583d42e9c67c357f34b9886d025bc9a369338a610e512338a6fc90870776c7b60382952c0c99361000daeadaedc005f13ad8f818ec92b509a9a2d186fb66509
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^5.1.0-rc-e948a5ac-20240807":
+"eslint-plugin-react-hooks@npm:^5.1.0-rc-49496d49-20240814":
   version: 5.1.0-rc-fb9a90fa48-20240614
   resolution: "eslint-plugin-react-hooks@npm:5.1.0-rc-fb9a90fa48-20240614"
   peerDependencies:
@@ -922,21 +917,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.9.0":
-  version: 1.9.0
-  resolution: "eslint-plugin-react-naming-convention@npm:1.9.0"
+"eslint-plugin-react-naming-convention@npm:1.10.1":
+  version: 1.10.1
+  resolution: "eslint-plugin-react-naming-convention@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/core": "npm:1.9.0"
-    "@eslint-react/jsx": "npm:1.9.0"
-    "@eslint-react/shared": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/type-utils": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
-    remeda: "npm:^2.7.1"
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/core": "npm:1.10.1"
+    "@eslint-react/jsx": "npm:1.10.1"
+    "@eslint-react/shared": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/type-utils": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+    ts-pattern: "npm:^5.3.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -945,7 +940,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/38a8de81d78a157db194e3ba957db5043728d9d3e0381ad1bdbae5123a7f5801e13c141cb10afbea5194be616dda08cc84b304015091e2868e04baf882a6d1cb
+  checksum: 10c0/ce64523ee92308084e884970c9247f2e03cdd1b74781be841262ee895b8fdfc7d5972ee0eba6df291163c340372e68621fa1486ca4349af218c44cc4bdfe2bd1
   languageName: node
   linkType: hard
 
@@ -958,23 +953,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.9.0":
-  version: 1.9.0
-  resolution: "eslint-plugin-react-x@npm:1.9.0"
+"eslint-plugin-react-x@npm:1.10.1":
+  version: 1.10.1
+  resolution: "eslint-plugin-react-x@npm:1.10.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.9.0"
-    "@eslint-react/core": "npm:1.9.0"
-    "@eslint-react/jsx": "npm:1.9.0"
-    "@eslint-react/shared": "npm:1.9.0"
-    "@eslint-react/tools": "npm:1.9.0"
-    "@eslint-react/types": "npm:1.9.0"
-    "@eslint-react/var": "npm:1.9.0"
-    "@typescript-eslint/scope-manager": "npm:^8.0.1"
-    "@typescript-eslint/type-utils": "npm:^8.0.1"
-    "@typescript-eslint/types": "npm:^8.0.1"
-    "@typescript-eslint/utils": "npm:^8.0.1"
+    "@eslint-react/ast": "npm:1.10.1"
+    "@eslint-react/core": "npm:1.10.1"
+    "@eslint-react/jsx": "npm:1.10.1"
+    "@eslint-react/shared": "npm:1.10.1"
+    "@eslint-react/tools": "npm:1.10.1"
+    "@eslint-react/types": "npm:1.10.1"
+    "@eslint-react/var": "npm:1.10.1"
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/type-utils": "npm:^8.1.0"
+    "@typescript-eslint/types": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
     is-immutable-type: "npm:5.0.0"
-    remeda: "npm:^2.7.1"
+    ts-pattern: "npm:^5.3.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -983,7 +978,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/1d1dfce4a1e1702b0a47b60e99813b60272a912793b97402d1ec32087e6ce6d9b49a60ee69d807fbabbcdeedf21b64e649644b0e2547b09e9a4e37369cccb2c8
+  checksum: 10c0/367fc413f85e03128c9053a0ae1543279aa996360a1e8eb961c2f8cf397368681bd616a3955e236981a567ee7e58bc49a92715cfc8f8dff14e30235303555db4
   languageName: node
   linkType: hard
 
@@ -1037,15 +1032,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.8.0":
-  version: 9.8.0
-  resolution: "eslint@npm:9.8.0"
+"eslint@npm:^9.9.0":
+  version: 9.9.0
+  resolution: "eslint@npm:9.9.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.11.0"
     "@eslint/config-array": "npm:^0.17.1"
     "@eslint/eslintrc": "npm:^3.1.0"
-    "@eslint/js": "npm:9.8.0"
+    "@eslint/js": "npm:9.9.0"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.3.0"
     "@nodelib/fs.walk": "npm:^1.2.8"
@@ -1075,9 +1070,14 @@ __metadata:
     optionator: "npm:^0.9.3"
     strip-ansi: "npm:^6.0.1"
     text-table: "npm:^0.2.0"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/a2ee0cce1147565d011fe185733af482f34d5466f5df5f390d0ea2ecf78097883cf568ed6c771d687138609c63cd55cd1e3ff12de7393c03f54fcffcdd0f225d
+  checksum: 10c0/3a22f68c99d75dcbafe6e2fef18d2b5bbcc960c2437f48a414ccf9ca214254733a18e6b79d07bbd374a2369a648413e421aabd07b11be3de5a44d5a4b9997877
   languageName: node
   linkType: hard
 
@@ -1291,9 +1291,9 @@ __metadata:
   linkType: hard
 
 "ignore@npm:^5.2.0, ignore@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "ignore@npm:5.3.1"
-  checksum: 10c0/703f7f45ffb2a27fb2c5a8db0c32e7dee66b33a225d28e8db4e1be6474795f606686a6e3bcc50e1aa12f2042db4c9d4a7d60af3250511de74620fbed052ea4cd
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2"
+  checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
   languageName: node
   linkType: hard
 
@@ -1385,10 +1385,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdoc-type-pratt-parser@npm:~4.0.0":
-  version: 4.0.0
-  resolution: "jsdoc-type-pratt-parser@npm:4.0.0"
-  checksum: 10c0/b23ef7bbbe2f56d72630d1c5a233dc9fecaff399063d373c57bef136908c1b05e723dac107177303c03ccf8d75aa51507510b282aa567600477479c5ea0c36d1
+"jsdoc-type-pratt-parser@npm:~4.1.0":
+  version: 4.1.0
+  resolution: "jsdoc-type-pratt-parser@npm:4.1.0"
+  checksum: 10c0/7700372d2e733a32f7ea0a1df9cec6752321a5345c11a91b2ab478a031a426e934f16d5c1f15c8566c7b2c10af9f27892a29c2c789039f595470e929a4aa60ea
   languageName: node
   linkType: hard
 
@@ -1657,15 +1657,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remeda@npm:^2.7.1":
-  version: 2.10.1
-  resolution: "remeda@npm:2.10.1"
-  dependencies:
-    type-fest: "npm:^4.23.0"
-  checksum: 10c0/6601ae5afcc509a8746a5b8b159ffb28e4d4a9dbdd22435e529772dc42c95cb2f233ea7d4403a4aa06ed5d34a4b5f758445068435877d64e95eeef4b1ed7a211
-  languageName: node
-  linkType: hard
-
 "requireindex@npm:^1.2.0":
   version: 1.2.0
   resolution: "requireindex@npm:1.2.0"
@@ -1726,7 +1717,7 @@ __metadata:
   dependencies:
     "@pandell/eslint-config": "workspace:packages/eslint-config"
     browserslist: "npm:^4.23.3"
-    eslint: "npm:^9.8.0"
+    eslint: "npm:^9.9.0"
     prettier: "npm:^3.3.3"
     typescript: "npm:^5.5.4"
   languageName: unknown
@@ -1906,10 +1897,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-pattern@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "ts-pattern@npm:5.2.0"
-  checksum: 10c0/99d0bc0d2f3aa19d8ff50b028f4e1c3da35b21f4503f329f8818863b614df3850c0b3709c703e18f5902e68b9682d29719c82b709e07907e87e374e5c70a01f5
+"ts-pattern@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "ts-pattern@npm:5.3.1"
+  checksum: 10c0/4d5082edb2d0a198a4f46abc834317fa2be616277be7721df71a93ea33180b85443ae2e92ff28a0cda51f038b5e347b35ad79936a55ed468e23268fbc48503a1
   languageName: node
   linkType: hard
 
@@ -1929,24 +1920,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.23.0":
-  version: 4.23.0
-  resolution: "type-fest@npm:4.23.0"
-  checksum: 10c0/c42bb14e99329ab37983d1f188e307bf0cc705a23807d9b2268d8fb2ae781d610ac6e2058dde8f9ea2b1b8ddc77ceb578d157fa81f69f8f70aef1d42fb002996
-  languageName: node
-  linkType: hard
-
-"typescript-eslint@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "typescript-eslint@npm:8.0.1"
+"typescript-eslint@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "typescript-eslint@npm:8.1.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.0.1"
-    "@typescript-eslint/parser": "npm:8.0.1"
-    "@typescript-eslint/utils": "npm:8.0.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.1.0"
+    "@typescript-eslint/parser": "npm:8.1.0"
+    "@typescript-eslint/utils": "npm:8.1.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/dc9df2dd82863b98720b7555c1fa6c2724055a252ce5940655187667253b717be8697bb798742f23701ee6efcd743d5556f00ab9a3af24a0e735df1e8b24e24a
+  checksum: 10c0/9b5769b95aeca54ae9fa15cd2f0e5656747f643a7be220513555de143ff19d70c5945eb82259a3fb29ab4d37f4d158f7f088e7b2cf98e2e8253a7429ac19d072
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `@eslint-react/eslint-plugin`
    - [1.9.1](https://github.com/Rel1cx/eslint-react/releases/tag/v1.9.1)
    - [1.10.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.10.0)
    - [1.10.1](https://github.com/Rel1cx/eslint-react/releases/tag/v1.10.1)
- `eslint`
    - [9.9.0](https://github.com/eslint/eslint/releases/tag/v9.9.0)
- `eslint-plugin-testing-library`
    - [6.3.0](https://github.com/testing-library/eslint-plugin-testing-library/releases/tag/v6.3.0)
    - Switch our configuration to `flat/react` configuration added in `6.3.0`
- `typescript-eslint`
    - [8.1.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.1.0)