### PR TITLE
@pandell/eslint-config: NPM update 2024-10-11

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "packageManager": "yarn@4.5.0",
   "devDependencies": {
     "@pandell/eslint-config": "workspace:packages/eslint-config",
-    "browserslist": "^4.23.3",
-    "eslint": "^9.10.0",
+    "browserslist": "^4.24.0",
+    "eslint": "^9.12.0",
     "prettier": "^3.3.3",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.3"
   },
   "prettier": "@pandell/prettier-config"
 }

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,13 +9,13 @@ Add the following to your `package.json`:
 ```jsonc
 {
   "devDependencies": {
-    "@pandell/eslint-config": "^9.3.0",
-    "eslint": "^9.10.0",
+    "@pandell/eslint-config": "^9.4.0",
+    "eslint": "^9.12.0",
     "eslint-plugin-testing-library": "^6.3.0", // only needed when using "testing: { enabledTestingLibrary: true }", see note 1 below
     // ...
   },
   "resolutions": {
-    "@typescript-eslint/utils": "^8.6.0" // only needed when including "eslint-plugin-testing-library"
+    "@typescript-eslint/utils": "^8.8.1" // only needed when including "eslint-plugin-testing-library"
   },
   // ...
 }
@@ -25,7 +25,7 @@ Add the following to your `package.json`:
 
 > **Note 1** (`eslint-plugin-testing-library`) While all other plugins can co-exist with ESLint 9 and
 are included as direct dependencies of `@pandell/eslint-config`, `eslint-plugin-testing-library` only
-supports ESLint 8 as of August 2024. We chose to reference it as an optional peer dependency, not regular
+supports ESLint 8 as of October 2024. We chose to reference it as an optional peer dependency, not regular
 dependency, thus it has to be added to your project's `package.json`. If you do not set
 `enabledTestingLibrary` property (or set it to `false`), you do not need to include this dependency.
 This recommendation will be removed in the future after `eslint-plugin-testing-library`

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,23 +25,24 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.14.1",
-    "@eslint/compat": "^1.1.1",
-    "@eslint/js": "^9.10.0",
-    "@tanstack/eslint-plugin-query": "^5.56.1",
-    "@vitest/eslint-plugin": "^1.1.4",
+    "@eslint-react/eslint-plugin": "^1.14.3",
+    "@eslint/compat": "^1.2.0",
+    "@eslint/js": "^9.12.0",
+    "@tanstack/eslint-plugin-query": "^5.59.7",
+    "@typescript-eslint/utils": "^8.8.1",
+    "@vitest/eslint-plugin": "^1.1.7",
     "eslint-import-resolver-typescript": "^3.6.3",
-    "eslint-plugin-import-x": "^4.2.1",
+    "eslint-plugin-import-x": "^4.3.1",
     "eslint-plugin-jest-dom": "^5.4.0",
-    "eslint-plugin-jsdoc": "^50.2.3",
-    "eslint-plugin-react-hooks": "5.1.0-rc-a99d8e8d-20240916",
+    "eslint-plugin-jsdoc": "^50.3.1",
+    "eslint-plugin-react-hooks": "5.1.0-rc-70fb1363-20241010",
     "eslint-plugin-react-refresh": "^0.4.12",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "typescript-eslint": "^8.6.0"
+    "typescript-eslint": "^8.8.1"
   },
   "devDependencies": {
-    "eslint": "^9.10.0",
-    "typescript": "^5.6.2"
+    "eslint": "^9.12.0",
+    "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "eslint": ">= 9",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,7 +25,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.14.3",
+    "@eslint-react/eslint-plugin": "^1.15.0",
     "@eslint/compat": "^1.2.0",
     "@eslint/js": "^9.12.0",
     "@tanstack/eslint-plugin-query": "^5.59.7",
@@ -34,8 +34,8 @@
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import-x": "^4.3.1",
     "eslint-plugin-jest-dom": "^5.4.0",
-    "eslint-plugin-jsdoc": "^50.3.1",
-    "eslint-plugin-react-hooks": "5.1.0-rc-70fb1363-20241010",
+    "eslint-plugin-jsdoc": "^50.3.2",
+    "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-react-refresh": "^0.4.12",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "typescript-eslint": "^8.8.1"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -29,16 +29,16 @@
     "@eslint/compat": "^1.2.0",
     "@eslint/js": "^9.12.0",
     "@tanstack/eslint-plugin-query": "^5.59.7",
-    "@typescript-eslint/utils": "^8.8.1",
+    "@typescript-eslint/utils": "^8.9.0",
     "@vitest/eslint-plugin": "^1.1.7",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import-x": "^4.3.1",
     "eslint-plugin-jest-dom": "^5.4.0",
-    "eslint-plugin-jsdoc": "^50.3.2",
+    "eslint-plugin-jsdoc": "^50.4.1",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-react-refresh": "^0.4.12",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "typescript-eslint": "^8.8.1"
+    "typescript-eslint": "^8.9.0"
   },
   "devDependencies": {
     "eslint": "^9.12.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/eslint-config",
   "type": "module",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "description": "Pandell ESLint shared config",
   "keywords": [
     "eslint",

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,60 +43,60 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/ast@npm:1.14.1"
+"@eslint-react/ast@npm:1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/ast@npm:1.14.3"
   dependencies:
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/typescript-estree": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/typescript-estree": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
     birecord: "npm:^0.1.1"
     string-ts: "npm:^2.2.0"
-    ts-pattern: "npm:^5.3.1"
-  checksum: 10c0/d6c667e1ae8f94990dfe20a833d68e870bc9f2d0b772ac663b1a0beac03478516f04da02d2047782740ccb28291e13450c9cb1a2569ffbd2ff38f39fb00385f0
+    ts-pattern: "npm:^5.4.0"
+  checksum: 10c0/f77925cc00e5fa53bc69ee617bdc735453453a7f79b71a2ed3cdb10e4473582b80d9fdccb79230bc6ab308b5bd005cda631bc93dbe9f94c70b20a55afa881e57
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/core@npm:1.14.1"
+"@eslint-react/core@npm:1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/core@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/jsx": "npm:1.14.1"
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@eslint-react/var": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/type-utils": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/jsx": "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@eslint-react/var": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/type-utils": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
     birecord: "npm:^0.1.1"
     short-unique-id: "npm:^5.2.0"
-    ts-pattern: "npm:^5.3.1"
-  checksum: 10c0/127f587c74546e649e53c5ebb5322cf5be065b11044b64185295a4804d3a4e74ab1304e208dbb4ebab2305515ab99ff15cbb7413105e8c25b569242425d9a681
+    ts-pattern: "npm:^5.4.0"
+  checksum: 10c0/c5816833c03f6bfc246e6a6306758bf84b57e7058898485c4c01c86f87ba6b4c1e67000ab3acdcd6fc4402f5c1b197f1d7398500039be494c426808f383ea7c5
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/eslint-plugin@npm:1.14.1"
+"@eslint-react/eslint-plugin@npm:^1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/eslint-plugin@npm:1.14.3"
   dependencies:
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/type-utils": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
-    eslint-plugin-react-debug: "npm:1.14.1"
-    eslint-plugin-react-dom: "npm:1.14.1"
-    eslint-plugin-react-hooks-extra: "npm:1.14.1"
-    eslint-plugin-react-naming-convention: "npm:1.14.1"
-    eslint-plugin-react-web-api: "npm:1.14.1"
-    eslint-plugin-react-x: "npm:1.14.1"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/type-utils": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
+    eslint-plugin-react-debug: "npm:1.14.3"
+    eslint-plugin-react-dom: "npm:1.14.3"
+    eslint-plugin-react-hooks-extra: "npm:1.14.3"
+    eslint-plugin-react-naming-convention: "npm:1.14.3"
+    eslint-plugin-react-web-api: "npm:1.14.3"
+    eslint-plugin-react-x: "npm:1.14.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -105,74 +105,79 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/9ed982632a5a2519aed0f843637480290ff2e17b616c6c03a874a060676286b4142ee4e8acef4548f35a1550fa5c33f04c4677e8386d9c723231a3e2307ce754
+  checksum: 10c0/7be3acc35db72a0a08f2dea110221c03a8173e1c5c9563df8c3557f047e2111e2c0435ad1293d5ea44da709b2fe252320c3b93282fef7acdfbb4e0977a3acbbd
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/jsx@npm:1.14.1"
+"@eslint-react/jsx@npm:1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/jsx@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@eslint-react/var": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
-    ts-pattern: "npm:^5.3.1"
-  checksum: 10c0/46e87a806ad26706f661dc77b226963ab4140dff5972459474bb29a87e1c44f41ecd6207f853453499970eab3aea47fe00b6a0023c9f6c732d2f986127df3009
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@eslint-react/var": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
+    ts-pattern: "npm:^5.4.0"
+  checksum: 10c0/823141a2822b5d3be888ee3e69d57e40c132771b0ab727fb848ea2a7476435eb63347195ea28daece9f88a8c07af0783bb0bf4110515bbe273ed424084508045
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/shared@npm:1.14.1"
+"@eslint-react/shared@npm:1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/shared@npm:1.14.3"
   dependencies:
-    "@eslint-react/tools": "npm:1.14.1"
-    "@typescript-eslint/utils": "npm:^8.5.0"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@typescript-eslint/utils": "npm:^8.7.0"
     picomatch: "npm:^4.0.2"
-  checksum: 10c0/cddc6042b5a006d92355096829ab874557f43c52b30a9c513ef2857dea0e74e40f65e764bdbf08fe2c327f0fd908e658d654ace914ad50290f83342dcde66305
+  checksum: 10c0/912119c2923ceeab1b72e20244909791f2e7c8e16859f502f4e8c434b3697c05c67b4da2fb70dbd684f84883d2641715e1814ec5ca7431277ae462499c556290
   languageName: node
   linkType: hard
 
-"@eslint-react/tools@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/tools@npm:1.14.1"
-  checksum: 10c0/a857a070987a5921d01a6b0b5cde4a859d57741db94d6d1058480c2fadc9cc845dcfdc52931e73632ea0e8c7c2d5d4f5877a785fb6103636feffb76a30af0551
+"@eslint-react/tools@npm:1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/tools@npm:1.14.3"
+  checksum: 10c0/17051457fcf6fe7c5976568daf04b66cc4ae93c5bcaa3cf5898ce25ac6fc7aa31fad26d7b30f3dcb1cab0d2fc836783fb638fc0762cb556af89104cd51bb0955
   languageName: node
   linkType: hard
 
-"@eslint-react/types@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/types@npm:1.14.1"
+"@eslint-react/types@npm:1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/types@npm:1.14.3"
   dependencies:
-    "@eslint-react/tools": "npm:1.14.1"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
-  checksum: 10c0/0ca4b44f43356cc72e14f9478b343b29a0d5c2c9a5a50abbd6aa84e0c8ea8fac5445b0f0e8bae2f2d5d65ec80f4812a11065a4e5d1edf00afdcded945ba6b0e8
+    "@eslint-react/tools": "npm:1.14.3"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
+  checksum: 10c0/b0613c8a14f53d2468f8faa65b6f2f8c79490044bf1f8e5765f0f85e65ec100bd0a047a48d77ea4cadc89e5b9bb4f755668ddbe8832808a949730435d5ebeccb
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@eslint-react/var@npm:1.14.1"
+"@eslint-react/var@npm:1.14.3":
+  version: 1.14.3
+  resolution: "@eslint-react/var@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
-    ts-pattern: "npm:^5.3.1"
-  checksum: 10c0/b7d62556bf114313294ea71cd56a9213b7e2ebb7ba7c773fb873e408b70b41a2af270b6e3a6e94ea20f8b8b41bd478c56663279a9d517d303a9ee09963309840
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
+    ts-pattern: "npm:^5.4.0"
+  checksum: 10c0/d867c755cfa6cbe0ea1bd880fb2460ee2e9a51caf6712c1c1d436572176873758b58a32ab844ee090a70c45d4ad0b4e0001db5ec8eb838e7c679d8ee8c85677c
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@eslint/compat@npm:1.1.1"
-  checksum: 10c0/ca8aa3811fa22d45913f5724978e6f3ae05fb7685b793de4797c9db3b0e22b530f0f492011b253754bffce879d7cece65762cc3391239b5d2249aef8230edc9a
+"@eslint/compat@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@eslint/compat@npm:1.2.0"
+  peerDependencies:
+    eslint: ^9.10.0
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: 10c0/ad79bf1ef14462f829288c4e2ca8eeffdf576fa923d3f8a07e752e821bdbe5fd79360fe6254e9ddfe7eada2e4e3d22a7ee09f5d21763e67bc4fbc331efb3c3e9
   languageName: node
   linkType: hard
 
@@ -184,6 +189,13 @@ __metadata:
     debug: "npm:^4.3.1"
     minimatch: "npm:^3.1.2"
   checksum: 10c0/0234aeb3e6b052ad2402a647d0b4f8a6aa71524bafe1adad0b8db1dfe94d7f5f26d67c80f79bb37ac61361a1d4b14bb8fb475efe501de37263cf55eabb79868f
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@eslint/core@npm:0.6.0"
+  checksum: 10c0/fffdb3046ad6420f8cb9204b6466fdd8632a9baeebdaf2a97d458a4eac0e16653ba50d82d61835d7d771f6ced0ec942ec482b2fbccc300e45f2cbf784537f240
   languageName: node
   linkType: hard
 
@@ -204,10 +216,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.10.0, @eslint/js@npm:^9.10.0":
-  version: 9.10.0
-  resolution: "@eslint/js@npm:9.10.0"
-  checksum: 10c0/2ac45a002dc1ccf25be46ea61001ada8d77248d1313ab4e53f3735e5ae00738a757874e41f62ad6fbd49df7dffeece66e5f53ff0d7b78a99ce4c68e8fea66753
+"@eslint/js@npm:9.12.0, @eslint/js@npm:^9.12.0":
+  version: 9.12.0
+  resolution: "@eslint/js@npm:9.12.0"
+  checksum: 10c0/325650a59a1ce3d97c69441501ebaf415607248bacbe8c8ca35adc7cb73b524f592f266a75772f496b06f3239e3ee1996722a242148085f0ee5fb3dd7065897c
   languageName: node
   linkType: hard
 
@@ -218,12 +230,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@eslint/plugin-kit@npm:0.1.0"
+"@eslint/plugin-kit@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@eslint/plugin-kit@npm:0.2.0"
   dependencies:
     levn: "npm:^0.4.1"
-  checksum: 10c0/fae97cd4efc1c32501c286abba1b5409848ce8c989e1ca6a5bb057a304a2cd721e6e957f6bc35ce95cfd0871e822ed42df3c759fecdad72c30e70802e26f83c7
+  checksum: 10c0/00b92bc52ad09b0e2bbbb30591c02a895f0bec3376759562590e8a57a13d096b22f8c8773b6bf791a7cf2ea614123b3d592fd006c51ac5fd0edbb90ea6d8760c
+  languageName: node
+  linkType: hard
+
+"@humanfs/core@npm:^0.19.0":
+  version: 0.19.0
+  resolution: "@humanfs/core@npm:0.19.0"
+  checksum: 10c0/f87952d5caba6ae427a620eff783c5d0b6cef0cfc256dec359cdaa636c5f161edb8d8dad576742b3de7f0b2f222b34aad6870248e4b7d2177f013426cbcda232
+  languageName: node
+  linkType: hard
+
+"@humanfs/node@npm:^0.16.5":
+  version: 0.16.5
+  resolution: "@humanfs/node@npm:0.16.5"
+  dependencies:
+    "@humanfs/core": "npm:^0.19.0"
+    "@humanwhocodes/retry": "npm:^0.3.0"
+  checksum: 10c0/41c365ab09e7c9eaeed373d09243195aef616d6745608a36fc3e44506148c28843872f85e69e2bf5f1e992e194286155a1c1cecfcece6a2f43875e37cd243935
   languageName: node
   linkType: hard
 
@@ -234,10 +263,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/retry@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@humanwhocodes/retry@npm:0.3.0"
-  checksum: 10c0/7111ec4e098b1a428459b4e3be5a5d2a13b02905f805a2468f4fa628d072f0de2da26a27d04f65ea2846f73ba51f4204661709f05bfccff645e3cedef8781bb6
+"@humanwhocodes/retry@npm:^0.3.0, @humanwhocodes/retry@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@humanwhocodes/retry@npm:0.3.1"
+  checksum: 10c0/f0da1282dfb45e8120480b9e2e275e2ac9bbe1cf016d046fdad8e27cc1285c45bb9e711681237944445157b430093412b4446c1ab3fc4bb037861b5904101d3b
   languageName: node
   linkType: hard
 
@@ -258,7 +287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:^1.2.3, @nodelib/fs.walk@npm:^1.2.8":
+"@nodelib/fs.walk@npm:^1.2.3":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -285,21 +314,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.14.1"
-    "@eslint/compat": "npm:^1.1.1"
-    "@eslint/js": "npm:^9.10.0"
-    "@tanstack/eslint-plugin-query": "npm:^5.56.1"
-    "@vitest/eslint-plugin": "npm:^1.1.4"
-    eslint: "npm:^9.10.0"
+    "@eslint-react/eslint-plugin": "npm:^1.14.3"
+    "@eslint/compat": "npm:^1.2.0"
+    "@eslint/js": "npm:^9.12.0"
+    "@tanstack/eslint-plugin-query": "npm:^5.59.7"
+    "@typescript-eslint/utils": "npm:^8.8.1"
+    "@vitest/eslint-plugin": "npm:^1.1.7"
+    eslint: "npm:^9.12.0"
     eslint-import-resolver-typescript: "npm:^3.6.3"
-    eslint-plugin-import-x: "npm:^4.2.1"
+    eslint-plugin-import-x: "npm:^4.3.1"
     eslint-plugin-jest-dom: "npm:^5.4.0"
-    eslint-plugin-jsdoc: "npm:^50.2.3"
-    eslint-plugin-react-hooks: "npm:5.1.0-rc-a99d8e8d-20240916"
+    eslint-plugin-jsdoc: "npm:^50.3.1"
+    eslint-plugin-react-hooks: "npm:5.1.0-rc-70fb1363-20241010"
     eslint-plugin-react-refresh: "npm:^0.4.12"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
-    typescript: "npm:^5.6.2"
-    typescript-eslint: "npm:^8.6.0"
+    typescript: "npm:^5.6.3"
+    typescript-eslint: "npm:^8.8.1"
   peerDependencies:
     eslint: ">= 9"
     eslint-plugin-testing-library: ">= 6.3.0"
@@ -352,26 +382,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/eslint-plugin-query@npm:^5.56.1":
-  version: 5.56.1
-  resolution: "@tanstack/eslint-plugin-query@npm:5.56.1"
+"@tanstack/eslint-plugin-query@npm:^5.59.7":
+  version: 5.59.7
+  resolution: "@tanstack/eslint-plugin-query@npm:5.59.7"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.3.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/9cca6913b63f952b3144e57d43d7abdb514b96a6d5fb8c27100115a4041a969d63695aed6541184348998b1f00a1950cafcbfd2ba0c46cacca533c1b9eeab550
+  checksum: 10c0/83ab51531b613d5f1015e1d0483b05fb27c654a8b6f40ed5dd1a6dcc48b221dd987c0bb9d9c64b6dd4632819599d93d5a85b431fc91d7846fdb1483551bda460
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.6.0"
+"@types/estree@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@types/estree@npm:1.0.6"
+  checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/eslint-plugin@npm:8.8.1":
+  version: 8.8.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.8.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.6.0"
-    "@typescript-eslint/type-utils": "npm:8.6.0"
-    "@typescript-eslint/utils": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
+    "@typescript-eslint/scope-manager": "npm:8.8.1"
+    "@typescript-eslint/type-utils": "npm:8.8.1"
+    "@typescript-eslint/utils": "npm:8.8.1"
+    "@typescript-eslint/visitor-keys": "npm:8.8.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -382,66 +426,66 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/c777f01535b896d3092f9886a67ccf9e50bf9e0f581ffab607c5e95dbf3092299b0d9f3e6041b134d69059a6fa5691785940b81015f73bb9a0e9d1605f6442ea
+  checksum: 10c0/020a0a482202b34c6665a56ec5902e38ae1870b2600ec1b2092de352b23099dde553781ee8323974f63962ebe164a6304f0019e937afb5cf7854b0e0163ad1ca
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/parser@npm:8.6.0"
+"@typescript-eslint/parser@npm:8.8.1":
+  version: 8.8.1
+  resolution: "@typescript-eslint/parser@npm:8.8.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.6.0"
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/typescript-estree": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
+    "@typescript-eslint/scope-manager": "npm:8.8.1"
+    "@typescript-eslint/types": "npm:8.8.1"
+    "@typescript-eslint/typescript-estree": "npm:8.8.1"
+    "@typescript-eslint/visitor-keys": "npm:8.8.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/3f280d289b486359194d422d89df9896b3f10a6d45cdf851d1d5f3200489271a31ab503c127cb5656f9b0ad6d795dd708b960f21fb105750aac19f41f8f815d1
+  checksum: 10c0/2afd147ccec6754316d6837d6108a5d822eb6071e1a7355073288c232530bc3e49901d3f08755ce02d497110c531f3b3658eb46d0ff875a69d4f360b5f938cb4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.6.0, @typescript-eslint/scope-manager@npm:^8.5.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.6.0"
+"@typescript-eslint/scope-manager@npm:8.8.1, @typescript-eslint/scope-manager@npm:^8.7.0":
+  version: 8.8.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.8.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
-  checksum: 10c0/37092ef70171c06854ac67ebfb2255063890c1c6133654e6b15b6adb6d2ab83de4feafd1599f4d02ed71a018226fcb3a389021758ec045e1904fb1798e90b4fe
+    "@typescript-eslint/types": "npm:8.8.1"
+    "@typescript-eslint/visitor-keys": "npm:8.8.1"
+  checksum: 10c0/6f697baf087aedc3f0f228ff964fd108a9dd33fe4e5cc6c914be6367c324cee55629e099832668042bedfec8cdc72c6ef2ca960ee26966dbcc75753059a1352f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.6.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.5.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/type-utils@npm:8.6.0"
+"@typescript-eslint/type-utils@npm:8.8.1, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.7.0":
+  version: 8.8.1
+  resolution: "@typescript-eslint/type-utils@npm:8.8.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.6.0"
-    "@typescript-eslint/utils": "npm:8.6.0"
+    "@typescript-eslint/typescript-estree": "npm:8.8.1"
+    "@typescript-eslint/utils": "npm:8.8.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/914b4637caa40c102117655a9b4451e0db611a61309ed39d6c57522655463c059f4dfd4e2d7ffdefcc9ab7533be21fb877b740c58f5be11f3530aa29f3d2cb62
+  checksum: 10c0/6edfc2b9fca5233dd922141f080377b677db1093ec3e702a3ab52d58f77b91c0fb69479d4d42f125536b8fc0ffa85c07c7de2f17cc4c6fa1df1226ec01e5608c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.6.0, @typescript-eslint/types@npm:^8.5.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/types@npm:8.6.0"
-  checksum: 10c0/e7051d212252f7d1905b5527b211e335db4ec5bb1d3a52d73c8d2de6ddf5cbc981f2c92ca9ffcef35f7447bda635ea1ccce5f884ade7f243d14f2a254982c698
+"@typescript-eslint/types@npm:8.8.1, @typescript-eslint/types@npm:^8.7.0":
+  version: 8.8.1
+  resolution: "@typescript-eslint/types@npm:8.8.1"
+  checksum: 10c0/4b44857332a0b1bfafbeccb8be157f8266d9e226ac723f6af1272b9b670b49444423ddac733655163eb3b90e8c88393a68ab2d7f326f5775371eaf4b9ca31d7b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.6.0, @typescript-eslint/typescript-estree@npm:^8.5.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.6.0"
+"@typescript-eslint/typescript-estree@npm:8.8.1, @typescript-eslint/typescript-estree@npm:^8.7.0":
+  version: 8.8.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.8.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
+    "@typescript-eslint/types": "npm:8.8.1"
+    "@typescript-eslint/visitor-keys": "npm:8.8.1"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -451,50 +495,48 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/33ab8c03221a797865301f09d1d198c67f8b0e3dbf0d13e41f699dc2740242303a9fcfd7b38302cef318541fdedd832fd6e8ba34a5041a57e9114fa134045385
+  checksum: 10c0/e3b9bc1e925c07833237044271cdc9bd8bdba3e2143dcfc5bf3bf481c89731b666a6fad25333a4b1980ac2f4c6f5e6e42c71206f73f3704e319f6b3b67463a6a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.6.0, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.3.0, @typescript-eslint/utils@npm:^8.5.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/utils@npm:8.6.0"
+"@typescript-eslint/utils@npm:8.8.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.3.0, @typescript-eslint/utils@npm:^8.7.0, @typescript-eslint/utils@npm:^8.8.1":
+  version: 8.8.1
+  resolution: "@typescript-eslint/utils@npm:8.8.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.6.0"
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/typescript-estree": "npm:8.6.0"
+    "@typescript-eslint/scope-manager": "npm:8.8.1"
+    "@typescript-eslint/types": "npm:8.8.1"
+    "@typescript-eslint/typescript-estree": "npm:8.8.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/5b615106342dfdf09f5a73e2554cc0c4d979c262a9a4548eb76ec7045768e0ff0bf0316cf8a5eb5404689cd476fcd335fc84f90eb985557559e42aeee33d687e
+  checksum: 10c0/954a2e85ae56a3ebefb6e41fb33c59ffa886963860536e9729a35ecea55eefdc58858c7aa126048c4a61f4fd9997b4f7601e7884ed2b3e4e7a46c9e4617a9f29
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.6.0"
+"@typescript-eslint/visitor-keys@npm:8.8.1":
+  version: 8.8.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.8.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.6.0"
+    "@typescript-eslint/types": "npm:8.8.1"
     eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10c0/9bd5d5daee9de7e009fdd1b64b1eca685a699d1b2639373bc279c97e25e769fff56fffef708ef66a2b19bc8bb201d36daf9e7084f0e0872178bfcf9d923b41f3
+  checksum: 10c0/6f917090b61277bd443aa851c532c4a9cc91ad57aedf185c5dff0c530f158cce84ef815833bd8deffa87f0bbf7a9f1abd1e02e30af2463c4e7f27c0c08f59080
   languageName: node
   linkType: hard
 
-"@vitest/eslint-plugin@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@vitest/eslint-plugin@npm:1.1.4"
+"@vitest/eslint-plugin@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@vitest/eslint-plugin@npm:1.1.7"
   peerDependencies:
     "@typescript-eslint/utils": ">= 8.0"
     eslint: ">= 8.57.0"
     typescript: ">= 5.0.0"
     vitest: "*"
   peerDependenciesMeta:
-    "@typescript-eslint/utils":
-      optional: true
     typescript:
       optional: true
     vitest:
       optional: true
-  checksum: 10c0/e1de76593acefa063498081978746750fcd4906f9de31a463e7675b98d44b0e600c1b9d54d1873f6c01efcf2230184f414d3a4e9a7933e7105ae60c0ea18591c
+  checksum: 10c0/a2c7e3361dcf02b214eaaead63838abd0a07f0fa6294871b61df4e5dc3ca951056acf75b64feeec196e12f129306dc5780601dd94a88f9df3c2e6623863b39f2
   languageName: node
   linkType: hard
 
@@ -525,13 +567,6 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "ansi-regex@npm:5.0.1"
-  checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
   languageName: node
   linkType: hard
 
@@ -600,17 +635,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.23.3":
-  version: 4.23.3
-  resolution: "browserslist@npm:4.23.3"
+"browserslist@npm:^4.24.0":
+  version: 4.24.0
+  resolution: "browserslist@npm:4.24.0"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001646"
-    electron-to-chromium: "npm:^1.5.4"
+    caniuse-lite: "npm:^1.0.30001663"
+    electron-to-chromium: "npm:^1.5.28"
     node-releases: "npm:^2.0.18"
     update-browserslist-db: "npm:^1.1.0"
   bin:
     browserslist: cli.js
-  checksum: 10c0/3063bfdf812815346447f4796c8f04601bf5d62003374305fd323c2a463e42776475bcc5309264e39bcf9a8605851e53560695991a623be988138b3ff8c66642
+  checksum: 10c0/95e76ad522753c4c470427f6e3c8a4bb5478ff448841e22b3d3e53f89ecaf17b6984666d6c7e715c370f1e7fa0cf684f42e34e554236a8b2fab38ea76b9e4c52
   languageName: node
   linkType: hard
 
@@ -621,10 +656,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001660
-  resolution: "caniuse-lite@npm:1.0.30001660"
-  checksum: 10c0/d28900b56c597176d515c3175ca75c454f2d30cb2c09a44d7bdb009bb0c4d8a2557905adb77642889bbe9feb85fbfe9d974c8b8e53521fb4b50ee16ab246104e
+"caniuse-lite@npm:^1.0.30001663":
+  version: 1.0.30001668
+  resolution: "caniuse-lite@npm:1.0.30001668"
+  checksum: 10c0/247b3200aeec55038f3a11f3e6ab66f656c54d30df7b01d8d447efaba9af96ad3e17128da2ddd42ddc9cb6c286bac65b634a20955b3cc6619be7ca4601fddc8e
   languageName: node
   linkType: hard
 
@@ -716,10 +751,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.4":
-  version: 1.5.25
-  resolution: "electron-to-chromium@npm:1.5.25"
-  checksum: 10c0/2ea818d22592754b902df70d48b82c5d9e3cc2a221d3d0c39d7a7967780601a5cebd5fa10628c6d0ba918582c268a20392279e8bee93edba2e499681056ae143
+"electron-to-chromium@npm:^1.5.28":
+  version: 1.5.36
+  resolution: "electron-to-chromium@npm:1.5.36"
+  checksum: 10c0/cd8d0de7801107f2b2744b5b18641c969a49b0503996cc1a586bb79d893020d0c4e916ac1935603eea65104b4fc1096bc339e0151531dca9e0f0ce0c1882e2d8
   languageName: node
   linkType: hard
 
@@ -740,7 +775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.2":
+"escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
   checksum: 10c0/ced4dd3a78e15897ed3be74e635110bbf3b08877b0a41be50dcb325ee0e0b5f65fc2d50e9845194d7c4633f327e2e1c6cce00a71b617c5673df0374201d67f65
@@ -791,20 +826,20 @@ __metadata:
   linkType: hard
 
 "eslint-module-utils@npm:^2.8.1":
-  version: 2.11.0
-  resolution: "eslint-module-utils@npm:2.11.0"
+  version: 2.12.0
+  resolution: "eslint-module-utils@npm:2.12.0"
   dependencies:
     debug: "npm:^3.2.7"
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: 10c0/c1b02e83429878ab22596f17a5ac138e51a520e96a5ef89a5a6698769a2d174ab28302d45eb563c0fc418d21a5842e328c37a6e8f294bf2e64e675ba55203dd7
+  checksum: 10c0/4d8b46dcd525d71276f9be9ffac1d2be61c9d54cc53c992e6333cf957840dee09381842b1acbbb15fc6b255ebab99cd481c5007ab438e5455a14abe1a0468558
   languageName: node
   linkType: hard
 
-"eslint-plugin-import-x@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "eslint-plugin-import-x@npm:4.2.1"
+"eslint-plugin-import-x@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "eslint-plugin-import-x@npm:4.3.1"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.1.0"
     debug: "npm:^4.3.4"
@@ -818,7 +853,7 @@ __metadata:
     tslib: "npm:^2.6.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/5a644448e2658e999ef01582011f24589920aa7c01ee45478481d0182fb9a21a0649c84d63fc4108f5bf2e2ce4c3d4c14930d7064224619230690a3240d98839
+  checksum: 10c0/47db6c6c90a5a3d2e4d3da36921a22e22042f9f3d4469a9d783d84658597e8fcbc88f71d7553c7a3f4c83ffad7a228fb3a85d4e9bf48361d5ea76bfb4a13df99
   languageName: node
   linkType: hard
 
@@ -838,9 +873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.2.3":
-  version: 50.2.3
-  resolution: "eslint-plugin-jsdoc@npm:50.2.3"
+"eslint-plugin-jsdoc@npm:^50.3.1":
+  version: 50.3.1
+  resolution: "eslint-plugin-jsdoc@npm:50.3.1"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.48.0"
     are-docs-informative: "npm:^0.0.2"
@@ -855,27 +890,27 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/244bfc815a082fac2d22867b6efb5ed25dd2a76e08ae1a6b83a522360a44138eea03d23450db947d969d015c17953a0925bad3926ce51856150a20e23fe6a954
+  checksum: 10c0/b4e8d58f02794917581d74936e2af947aea3b518c4ad670866caa0b3f1f25cfec08414567c19d580a77d84431b2477f0a4075be500bb27b715013c59679f307e
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.14.1":
-  version: 1.14.1
-  resolution: "eslint-plugin-react-debug@npm:1.14.1"
+"eslint-plugin-react-debug@npm:1.14.3":
+  version: 1.14.3
+  resolution: "eslint-plugin-react-debug@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/core": "npm:1.14.1"
-    "@eslint-react/jsx": "npm:1.14.1"
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@eslint-react/var": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/type-utils": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/core": "npm:1.14.3"
+    "@eslint-react/jsx": "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@eslint-react/var": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/type-utils": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
     string-ts: "npm:^2.2.0"
-    ts-pattern: "npm:^5.3.1"
+    ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -884,25 +919,25 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/42cc90325f889d246a6862dea11bacfe1e6111cbda36cfff72f16f508d1a448ef82d64607360d14ba54bd1c20388323d141370004d0cee561bcd3e4c15e7eb21
+  checksum: 10c0/3fdd7e2c4eff3f5e52394e6a7bba1e55982250e8e705bcaff8eba483ce306b4dee3fd5104508769f017f742ae80b27050ddad2fd4fd3e886dd9f25b68e90b485
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.14.1":
-  version: 1.14.1
-  resolution: "eslint-plugin-react-dom@npm:1.14.1"
+"eslint-plugin-react-dom@npm:1.14.3":
+  version: 1.14.3
+  resolution: "eslint-plugin-react-dom@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/core": "npm:1.14.1"
-    "@eslint-react/jsx": "npm:1.14.1"
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@eslint-react/var": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
-    ts-pattern: "npm:^5.3.1"
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/core": "npm:1.14.3"
+    "@eslint-react/jsx": "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@eslint-react/var": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
+    ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -911,26 +946,26 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/9d56487679b0e30b514b1c34b4cb3fe3b93d8c2b9a3f05e7e7ced36b3326397d28f2e51cf249e65ee2c82520162a88fc401c780a87e3c951bef6ea2b533a80a4
+  checksum: 10c0/dfbc8541ae94848f06ffbeb614472b0948208a683ae92a07f265c3ff305fc2c50257a3b96078a12a5c2827e887a4dec7cf0ed87aa465f030634ee47892a047d3
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.14.1":
-  version: 1.14.1
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.14.1"
+"eslint-plugin-react-hooks-extra@npm:1.14.3":
+  version: 1.14.3
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/core": "npm:1.14.1"
-    "@eslint-react/jsx": "npm:1.14.1"
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@eslint-react/var": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/type-utils": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
-    ts-pattern: "npm:^5.3.1"
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/core": "npm:1.14.3"
+    "@eslint-react/jsx": "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@eslint-react/var": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/type-utils": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
+    ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -939,34 +974,34 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/66c0376363fe31219d5f3e604fe5c16575dde0a658b0f30cd292d55f286b0ecca7cabcf0a7c6bea5722c4b88cf59b2ead56972292600969d179c7cfb1b66639c
+  checksum: 10c0/6205e48224e9d5097eaabca9b364bdd69d0068b1783ee265f4caa511d319745dad3dc958dcb479b2c56624a34cc3f37e64e8699b9107b1c8e2ae05c8c2f44322
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:5.1.0-rc-a99d8e8d-20240916":
-  version: 5.1.0-rc-a99d8e8d-20240916
-  resolution: "eslint-plugin-react-hooks@npm:5.1.0-rc-a99d8e8d-20240916"
+"eslint-plugin-react-hooks@npm:5.1.0-rc-70fb1363-20241010":
+  version: 5.1.0-rc-70fb1363-20241010
+  resolution: "eslint-plugin-react-hooks@npm:5.1.0-rc-70fb1363-20241010"
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10c0/42d2278ab5eb851a0350a340d23667f10cf7bde1cd64db283e7a8e04268f098e6540bfb09accd8b8edc05e7b40d7337cee29d9ccbbaf38bd1e8f9c7c39e133d9
+  checksum: 10c0/99d54a8bc6ba3e1f1c78bb89da8674bcdd70faa239118dd62419d1126d4e5c7a649d00588dc667a784632f9d70a825e7338dcf970f832b373fa4fd0d0749a5c8
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.14.1":
-  version: 1.14.1
-  resolution: "eslint-plugin-react-naming-convention@npm:1.14.1"
+"eslint-plugin-react-naming-convention@npm:1.14.3":
+  version: 1.14.3
+  resolution: "eslint-plugin-react-naming-convention@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/core": "npm:1.14.1"
-    "@eslint-react/jsx": "npm:1.14.1"
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/type-utils": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
-    ts-pattern: "npm:^5.3.1"
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/core": "npm:1.14.3"
+    "@eslint-react/jsx": "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/type-utils": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
+    ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -975,7 +1010,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/81ad127d8e80813b14a2154805e1a567aaa682b301509175ca32a54e7452e9eff4be3ab306279743b87bc9a80bb4cd5725d24e834768c7620d658b3487085eaf
+  checksum: 10c0/63cf167a5e483143d6d3ccd5e54530f154f5c61a6672116b5d30e075c8e732668b1876c448eaebf5ca5038d22c59c2fd51276b2e53e842f7fbc6695fce78f827
   languageName: node
   linkType: hard
 
@@ -988,22 +1023,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.14.1":
-  version: 1.14.1
-  resolution: "eslint-plugin-react-web-api@npm:1.14.1"
+"eslint-plugin-react-web-api@npm:1.14.3":
+  version: 1.14.3
+  resolution: "eslint-plugin-react-web-api@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/core": "npm:1.14.1"
-    "@eslint-react/jsx": "npm:1.14.1"
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@eslint-react/var": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/core": "npm:1.14.3"
+    "@eslint-react/jsx": "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@eslint-react/var": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
     birecord: "npm:^0.1.1"
-    ts-pattern: "npm:^5.3.1"
+    ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -1012,27 +1047,27 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/bd496aef0cac0e541613afd5f0c8a34d584d12283c26132e08202233e3d3c04c5882162157b73d4eb522baa209ba44eb38a0b7567f05ec28e5bf4c4dda77669c
+  checksum: 10c0/d3642050679ecb0c9d1aa37772eb147afae48b8aa4c20bc16b7b1f0e500303d15ec03014d8338bbdf6afd2b9811c52880e3202b65cd59322f791be487aeb1d94
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.14.1":
-  version: 1.14.1
-  resolution: "eslint-plugin-react-x@npm:1.14.1"
+"eslint-plugin-react-x@npm:1.14.3":
+  version: 1.14.3
+  resolution: "eslint-plugin-react-x@npm:1.14.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.1"
-    "@eslint-react/core": "npm:1.14.1"
-    "@eslint-react/jsx": "npm:1.14.1"
-    "@eslint-react/shared": "npm:1.14.1"
-    "@eslint-react/tools": "npm:1.14.1"
-    "@eslint-react/types": "npm:1.14.1"
-    "@eslint-react/var": "npm:1.14.1"
-    "@typescript-eslint/scope-manager": "npm:^8.5.0"
-    "@typescript-eslint/type-utils": "npm:^8.5.0"
-    "@typescript-eslint/types": "npm:^8.5.0"
-    "@typescript-eslint/utils": "npm:^8.5.0"
+    "@eslint-react/ast": "npm:1.14.3"
+    "@eslint-react/core": "npm:1.14.3"
+    "@eslint-react/jsx": "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.14.3"
+    "@eslint-react/tools": "npm:1.14.3"
+    "@eslint-react/types": "npm:1.14.3"
+    "@eslint-react/var": "npm:1.14.3"
+    "@typescript-eslint/scope-manager": "npm:^8.7.0"
+    "@typescript-eslint/type-utils": "npm:^8.7.0"
+    "@typescript-eslint/types": "npm:^8.7.0"
+    "@typescript-eslint/utils": "npm:^8.7.0"
     is-immutable-type: "npm:5.0.0"
-    ts-pattern: "npm:^5.3.1"
+    ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -1041,7 +1076,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/74ccf8d06cdd67d27db0bfd525e46b3e52037e1a55b27221a454d99263dcc722e70c5948b069b81b59cdc775060091babb59c5bdbf1e51e318c459d6397f981f
+  checksum: 10c0/35cca09d456d5863ba0e8c6384fd04beb12aff12710633e088ea313b24dc1b4ba1e91e4aaa1c0ae53a88b64b10c9acc68ac1e4c1194f541bdc84461f2018c9b0
   languageName: node
   linkType: hard
 
@@ -1054,13 +1089,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "eslint-scope@npm:8.0.2"
+"eslint-scope@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "eslint-scope@npm:8.1.0"
   dependencies:
     esrecurse: "npm:^4.3.0"
     estraverse: "npm:^5.2.0"
-  checksum: 10c0/477f820647c8755229da913025b4567347fd1f0bf7cbdf3a256efff26a7e2e130433df052bd9e3d014025423dc00489bea47eb341002b15553673379c1a7dc36
+  checksum: 10c0/ae1df7accae9ea90465c2ded70f7064d6d1f2962ef4cc87398855c4f0b3a5ab01063e0258d954bb94b184f6759febe04c3118195cab5c51978a7229948ba2875
   languageName: node
   linkType: hard
 
@@ -1071,34 +1106,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "eslint-visitor-keys@npm:4.0.0"
-  checksum: 10c0/76619f42cf162705a1515a6868e6fc7567e185c7063a05621a8ac4c3b850d022661262c21d9f1fc1d144ecf0d5d64d70a3f43c15c3fc969a61ace0fb25698cf5
+"eslint-visitor-keys@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "eslint-visitor-keys@npm:4.1.0"
+  checksum: 10c0/5483ef114c93a136aa234140d7aa3bd259488dae866d35cb0d0b52e6a158f614760a57256ac8d549acc590a87042cb40f6951815caa821e55dc4fd6ef4c722eb
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.10.0":
-  version: 9.10.0
-  resolution: "eslint@npm:9.10.0"
+"eslint@npm:^9.12.0":
+  version: 9.12.0
+  resolution: "eslint@npm:9.12.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.11.0"
     "@eslint/config-array": "npm:^0.18.0"
+    "@eslint/core": "npm:^0.6.0"
     "@eslint/eslintrc": "npm:^3.1.0"
-    "@eslint/js": "npm:9.10.0"
-    "@eslint/plugin-kit": "npm:^0.1.0"
+    "@eslint/js": "npm:9.12.0"
+    "@eslint/plugin-kit": "npm:^0.2.0"
+    "@humanfs/node": "npm:^0.16.5"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.3.0"
-    "@nodelib/fs.walk": "npm:^1.2.8"
+    "@humanwhocodes/retry": "npm:^0.3.1"
+    "@types/estree": "npm:^1.0.6"
+    "@types/json-schema": "npm:^7.0.15"
     ajv: "npm:^6.12.4"
     chalk: "npm:^4.0.0"
     cross-spawn: "npm:^7.0.2"
     debug: "npm:^4.3.2"
     escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.0.2"
-    eslint-visitor-keys: "npm:^4.0.0"
-    espree: "npm:^10.1.0"
+    eslint-scope: "npm:^8.1.0"
+    eslint-visitor-keys: "npm:^4.1.0"
+    espree: "npm:^10.2.0"
     esquery: "npm:^1.5.0"
     esutils: "npm:^2.0.2"
     fast-deep-equal: "npm:^3.1.3"
@@ -1108,13 +1146,11 @@ __metadata:
     ignore: "npm:^5.2.0"
     imurmurhash: "npm:^0.1.4"
     is-glob: "npm:^4.0.0"
-    is-path-inside: "npm:^3.0.3"
     json-stable-stringify-without-jsonify: "npm:^1.0.1"
     lodash.merge: "npm:^4.6.2"
     minimatch: "npm:^3.1.2"
     natural-compare: "npm:^1.4.0"
     optionator: "npm:^0.9.3"
-    strip-ansi: "npm:^6.0.1"
     text-table: "npm:^0.2.0"
   peerDependencies:
     jiti: "*"
@@ -1123,18 +1159,18 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/7357f3995b15043eea83c8c0ab16c385ce3f28925c1b11cfcd6b2ede8faab3d91ede84a68173dd5f6e3e176e177984e6218de58b7b8388e53e2881f1ec07c836
+  checksum: 10c0/67cf6ea3ea28dcda7dd54aac33e2d4028eb36991d13defb0d2339c3eaa877d5dddd12cd4416ddc701a68bcde9e0bb9e65524c2e4e9914992c724f5b51e949dda
   languageName: node
   linkType: hard
 
-"espree@npm:^10.0.1, espree@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "espree@npm:10.1.0"
+"espree@npm:^10.0.1, espree@npm:^10.1.0, espree@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "espree@npm:10.2.0"
   dependencies:
     acorn: "npm:^8.12.0"
     acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^4.0.0"
-  checksum: 10c0/52e6feaa77a31a6038f0c0e3fce93010a4625701925b0715cd54a2ae190b3275053a0717db698697b32653788ac04845e489d6773b508d6c2e8752f3c57470a0
+    eslint-visitor-keys: "npm:^4.1.0"
+  checksum: 10c0/2b6bfb683e7e5ab2e9513949879140898d80a2d9867ea1db6ff5b0256df81722633b60a7523a7c614f05a39aeea159dd09ad2a0e90c0e218732fc016f9086215
   languageName: node
   linkType: hard
 
@@ -1408,13 +1444,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-path-inside@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "is-path-inside@npm:3.0.3"
-  checksum: 10c0/cf7d4ac35fb96bab6a1d2c3598fe5ebb29aafb52c0aaa482b5a3ed9d8ba3edc11631e3ec2637660c44b3ce0e61a08d54946e8af30dec0b60a7c27296c68ffd05
-  languageName: node
-  linkType: hard
-
 "isexe@npm:^2.0.0":
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
@@ -1603,12 +1632,12 @@ __metadata:
   linkType: hard
 
 "parse-imports@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "parse-imports@npm:2.1.1"
+  version: 2.2.1
+  resolution: "parse-imports@npm:2.2.1"
   dependencies:
     es-module-lexer: "npm:^1.5.3"
     slashes: "npm:^3.0.12"
-  checksum: 10c0/c9bb0b4e1823f84f034d2d7bd2b37415b1715a5c963fda14968c706186b48b02c10e97d04bce042b9dcd679b42f29c391ea120799ddf581c7f54786edd99e3a9
+  checksum: 10c0/bc541ce4ef2ff77d53247de39a956e0ee7a1a4b9b175c3e0f898222fe7994595f011491154db4ed408cbaf5049ede9d0b6624125565be208e973a54420cbe069
   languageName: node
   linkType: hard
 
@@ -1633,7 +1662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.1":
+"picocolors@npm:^1.1.0":
   version: 1.1.0
   resolution: "picocolors@npm:1.1.0"
   checksum: 10c0/86946f6032148801ef09c051c6fb13b5cf942eaf147e30ea79edb91dd32d700934edebe782a1078ff859fb2b816792e97ef4dab03d7f0b804f6b01a0df35e023
@@ -1750,10 +1779,10 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@pandell/eslint-config": "workspace:packages/eslint-config"
-    browserslist: "npm:^4.23.3"
-    eslint: "npm:^9.10.0"
+    browserslist: "npm:^4.24.0"
+    eslint: "npm:^9.12.0"
     prettier: "npm:^3.3.3"
-    typescript: "npm:^5.6.2"
+    typescript: "npm:^5.6.3"
   languageName: unknown
   linkType: soft
 
@@ -1846,15 +1875,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "strip-ansi@npm:6.0.1"
-  dependencies:
-    ansi-regex: "npm:^5.0.1"
-  checksum: 10c0/1ae5f212a126fe5b167707f716942490e3933085a5ff6c008ab97ab2f272c8025d3aa218b7bd6ab25729ca20cc81cddb252102f8751e13482a5199e873680952
-  languageName: node
-  linkType: hard
-
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -1879,12 +1899,12 @@ __metadata:
   linkType: hard
 
 "synckit@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "synckit@npm:0.9.1"
+  version: 0.9.2
+  resolution: "synckit@npm:0.9.2"
   dependencies:
     "@pkgr/core": "npm:^0.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d8b89e1bf30ba3ffb469d8418c836ad9c0c062bf47028406b4d06548bc66af97155ea2303b96c93bf5c7c0f0d66153a6fbd6924c76521b434e6a9898982abc2e
+  checksum: 10c0/e0c262817444e5b872708adb6f5ad37951ba33f6b2d1d4477d45db1f57573a784618ceed5e6614e0225db330632b1f6b95bb74d21e4d013e45ad4bde03d0cb59
   languageName: node
   linkType: hard
 
@@ -1931,10 +1951,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-pattern@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "ts-pattern@npm:5.3.1"
-  checksum: 10c0/4d5082edb2d0a198a4f46abc834317fa2be616277be7721df71a93ea33180b85443ae2e92ff28a0cda51f038b5e347b35ad79936a55ed468e23268fbc48503a1
+"ts-pattern@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "ts-pattern@npm:5.4.0"
+  checksum: 10c0/8b7b785e51af736d110e181e8338fb74baafacf32f017b9df4f26bbefb295175f60d7cc22e23e77e9219930b2d3126aa1b0322bce210c9e18bede81cb4c2d2a5
   languageName: node
   linkType: hard
 
@@ -1954,51 +1974,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "typescript-eslint@npm:8.6.0"
+"typescript-eslint@npm:^8.8.1":
+  version: 8.8.1
+  resolution: "typescript-eslint@npm:8.8.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.6.0"
-    "@typescript-eslint/parser": "npm:8.6.0"
-    "@typescript-eslint/utils": "npm:8.6.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.8.1"
+    "@typescript-eslint/parser": "npm:8.8.1"
+    "@typescript-eslint/utils": "npm:8.8.1"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/d009170af1cffece3a63784c3f6d6f5074fd42d198540f3140dd0fed4f37b1888d59abb5992624099834cae2ea4863b6c526b5f11ecbfd105f41a87e300305db
+  checksum: 10c0/d6793697fce239ef8838ced6e1e59940c30579c8f62c49bc605fdeda9f3f7a5c24bfddd997b142f8c411859dc0b9985ecdae569814dd4f8e6775e1899d55e9cc
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.6.2":
-  version: 5.6.2
-  resolution: "typescript@npm:5.6.2"
+"typescript@npm:^5.6.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/3ed8297a8c7c56b7fec282532503d1ac795239d06e7c4966b42d4330c6cf433a170b53bcf93a130a7f14ccc5235de5560df4f1045eb7f3550b46ebed16d3c5e5
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>":
-  version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
+"typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
+  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
   languageName: node
   linkType: hard
 
 "update-browserslist-db@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "update-browserslist-db@npm:1.1.0"
+  version: 1.1.1
+  resolution: "update-browserslist-db@npm:1.1.1"
   dependencies:
-    escalade: "npm:^3.1.2"
-    picocolors: "npm:^1.0.1"
+    escalade: "npm:^3.2.0"
+    picocolors: "npm:^1.1.0"
   peerDependencies:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10c0/a7452de47785842736fb71547651c5bbe5b4dc1e3722ccf48a704b7b34e4dcf633991eaa8e4a6a517ffb738b3252eede3773bef673ef9021baa26b056d63a5b9
+  checksum: 10c0/536a2979adda2b4be81b07e311bd2f3ad5e978690987956bc5f514130ad50cac87cd22c710b686d79731e00fbee8ef43efe5fcd72baa241045209195d43dcc80
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,14 +14,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@es-joy/jsdoccomment@npm:~0.48.0":
-  version: 0.48.0
-  resolution: "@es-joy/jsdoccomment@npm:0.48.0"
+"@es-joy/jsdoccomment@npm:~0.49.0":
+  version: 0.49.0
+  resolution: "@es-joy/jsdoccomment@npm:0.49.0"
   dependencies:
     comment-parser: "npm:1.4.1"
     esquery: "npm:^1.6.0"
     jsdoc-type-pratt-parser: "npm:~4.1.0"
-  checksum: 10c0/8d87c7c0426fade009c30ab429d4ede53fd253d40b55079c02bdacdaa4c0fe904aaea5e3084cd98052f2bed6b3030c381d84f4a3251b343a71fee6f681a08bee
+  checksum: 10c0/16717507d557d37e7b59456fedeefbe0a3bc93aa2d9c043d5db91e24e076509b6fcb10ee6fd1dafcb0c5bbe50ae329b45de5b83541cb5994a98c9e862a45641e
   languageName: node
   linkType: hard
 
@@ -318,18 +318,18 @@ __metadata:
     "@eslint/compat": "npm:^1.2.0"
     "@eslint/js": "npm:^9.12.0"
     "@tanstack/eslint-plugin-query": "npm:^5.59.7"
-    "@typescript-eslint/utils": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.9.0"
     "@vitest/eslint-plugin": "npm:^1.1.7"
     eslint: "npm:^9.12.0"
     eslint-import-resolver-typescript: "npm:^3.6.3"
     eslint-plugin-import-x: "npm:^4.3.1"
     eslint-plugin-jest-dom: "npm:^5.4.0"
-    eslint-plugin-jsdoc: "npm:^50.3.2"
+    eslint-plugin-jsdoc: "npm:^50.4.1"
     eslint-plugin-react-hooks: "npm:5.0.0"
     eslint-plugin-react-refresh: "npm:^0.4.12"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     typescript: "npm:^5.6.3"
-    typescript-eslint: "npm:^8.8.1"
+    typescript-eslint: "npm:^8.9.0"
   peerDependencies:
     eslint: ">= 9"
     eslint-plugin-testing-library: ">= 6.3.0"
@@ -407,15 +407,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.8.1"
+"@typescript-eslint/eslint-plugin@npm:8.9.0":
+  version: 8.9.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.9.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.8.1"
-    "@typescript-eslint/type-utils": "npm:8.8.1"
-    "@typescript-eslint/utils": "npm:8.8.1"
-    "@typescript-eslint/visitor-keys": "npm:8.8.1"
+    "@typescript-eslint/scope-manager": "npm:8.9.0"
+    "@typescript-eslint/type-utils": "npm:8.9.0"
+    "@typescript-eslint/utils": "npm:8.9.0"
+    "@typescript-eslint/visitor-keys": "npm:8.9.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -426,66 +426,66 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/020a0a482202b34c6665a56ec5902e38ae1870b2600ec1b2092de352b23099dde553781ee8323974f63962ebe164a6304f0019e937afb5cf7854b0e0163ad1ca
+  checksum: 10c0/07f273dc270268980bbf65ea5e0c69d05377e42dbdb2dd3f4a1293a3536c049ddfb548eb9ec6e60394c2361c4a15b62b8246951f83e16a9d16799578a74dc691
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/parser@npm:8.8.1"
+"@typescript-eslint/parser@npm:8.9.0":
+  version: 8.9.0
+  resolution: "@typescript-eslint/parser@npm:8.9.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.8.1"
-    "@typescript-eslint/types": "npm:8.8.1"
-    "@typescript-eslint/typescript-estree": "npm:8.8.1"
-    "@typescript-eslint/visitor-keys": "npm:8.8.1"
+    "@typescript-eslint/scope-manager": "npm:8.9.0"
+    "@typescript-eslint/types": "npm:8.9.0"
+    "@typescript-eslint/typescript-estree": "npm:8.9.0"
+    "@typescript-eslint/visitor-keys": "npm:8.9.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/2afd147ccec6754316d6837d6108a5d822eb6071e1a7355073288c232530bc3e49901d3f08755ce02d497110c531f3b3658eb46d0ff875a69d4f360b5f938cb4
+  checksum: 10c0/aca7c838de85fb700ecf5682dc6f8f90a0fbfe09a3044a176c0dc3ffd9c5e7105beb0919a30824f46b02223a74119b4f5a9834a0663328987f066cb359b5dbed
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.8.1, @typescript-eslint/scope-manager@npm:^8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.8.1"
+"@typescript-eslint/scope-manager@npm:8.9.0, @typescript-eslint/scope-manager@npm:^8.8.1":
+  version: 8.9.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.9.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.8.1"
-    "@typescript-eslint/visitor-keys": "npm:8.8.1"
-  checksum: 10c0/6f697baf087aedc3f0f228ff964fd108a9dd33fe4e5cc6c914be6367c324cee55629e099832668042bedfec8cdc72c6ef2ca960ee26966dbcc75753059a1352f
+    "@typescript-eslint/types": "npm:8.9.0"
+    "@typescript-eslint/visitor-keys": "npm:8.9.0"
+  checksum: 10c0/1fb77a982e3384d8cabd64678ea8f9de328708080ff9324bf24a44da4e8d7b7692ae4820efc3ef36027bf0fd6a061680d3c30ce63d661fb31e18970fca5e86c5
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.8.1, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/type-utils@npm:8.8.1"
+"@typescript-eslint/type-utils@npm:8.9.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.8.1":
+  version: 8.9.0
+  resolution: "@typescript-eslint/type-utils@npm:8.9.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.8.1"
-    "@typescript-eslint/utils": "npm:8.8.1"
+    "@typescript-eslint/typescript-estree": "npm:8.9.0"
+    "@typescript-eslint/utils": "npm:8.9.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/6edfc2b9fca5233dd922141f080377b677db1093ec3e702a3ab52d58f77b91c0fb69479d4d42f125536b8fc0ffa85c07c7de2f17cc4c6fa1df1226ec01e5608c
+  checksum: 10c0/aff06afda9ac7d12f750e76c8f91ed8b56eefd3f3f4fbaa93a64411ec9e0bd2c2972f3407e439320d98062b16f508dce7604b8bb2b803fded9d3148e5ee721b1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.8.1, @typescript-eslint/types@npm:^8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/types@npm:8.8.1"
-  checksum: 10c0/4b44857332a0b1bfafbeccb8be157f8266d9e226ac723f6af1272b9b670b49444423ddac733655163eb3b90e8c88393a68ab2d7f326f5775371eaf4b9ca31d7b
+"@typescript-eslint/types@npm:8.9.0, @typescript-eslint/types@npm:^8.8.1":
+  version: 8.9.0
+  resolution: "@typescript-eslint/types@npm:8.9.0"
+  checksum: 10c0/8d901b7ed2f943624c24f7fa67f7be9d49a92554d54c4f27397c05b329ceff59a9ea246810b53ff36fca08760c14305dd4ce78fbac7ca0474311b0575bf49010
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.8.1, @typescript-eslint/typescript-estree@npm:^8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.8.1"
+"@typescript-eslint/typescript-estree@npm:8.9.0, @typescript-eslint/typescript-estree@npm:^8.8.1":
+  version: 8.9.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.9.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.8.1"
-    "@typescript-eslint/visitor-keys": "npm:8.8.1"
+    "@typescript-eslint/types": "npm:8.9.0"
+    "@typescript-eslint/visitor-keys": "npm:8.9.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -495,31 +495,31 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/e3b9bc1e925c07833237044271cdc9bd8bdba3e2143dcfc5bf3bf481c89731b666a6fad25333a4b1980ac2f4c6f5e6e42c71206f73f3704e319f6b3b67463a6a
+  checksum: 10c0/bb5ec70727f07d1575e95f9d117762636209e1ab073a26c4e873e1e5b4617b000d300a23d294ad81693f7e99abe3e519725452c30b235a253edcd85b6ae052b0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.8.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.3.0, @typescript-eslint/utils@npm:^8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/utils@npm:8.8.1"
+"@typescript-eslint/utils@npm:8.9.0, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.3.0, @typescript-eslint/utils@npm:^8.8.1, @typescript-eslint/utils@npm:^8.9.0":
+  version: 8.9.0
+  resolution: "@typescript-eslint/utils@npm:8.9.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.8.1"
-    "@typescript-eslint/types": "npm:8.8.1"
-    "@typescript-eslint/typescript-estree": "npm:8.8.1"
+    "@typescript-eslint/scope-manager": "npm:8.9.0"
+    "@typescript-eslint/types": "npm:8.9.0"
+    "@typescript-eslint/typescript-estree": "npm:8.9.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/954a2e85ae56a3ebefb6e41fb33c59ffa886963860536e9729a35ecea55eefdc58858c7aa126048c4a61f4fd9997b4f7601e7884ed2b3e4e7a46c9e4617a9f29
+  checksum: 10c0/af13e3d501060bdc5fa04b131b3f9a90604e5c1d4845d1f8bd94b703a3c146a76debfc21fe65a7f3a0459ed6c57cf2aa3f0a052469bb23b6f35ff853fe9495b1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.8.1":
-  version: 8.8.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.8.1"
+"@typescript-eslint/visitor-keys@npm:8.9.0":
+  version: 8.9.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.9.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.8.1"
+    "@typescript-eslint/types": "npm:8.9.0"
     eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10c0/6f917090b61277bd443aa851c532c4a9cc91ad57aedf185c5dff0c530f158cce84ef815833bd8deffa87f0bbf7a9f1abd1e02e30af2463c4e7f27c0c08f59080
+  checksum: 10c0/e33208b946841f1838d87d64f4ee230f798e68bdce8c181d3ac0abb567f758cb9c4bdccc919d493167869f413ca4c400e7db0f7dd7e8fc84ab6a8344076a7458
   languageName: node
   linkType: hard
 
@@ -752,9 +752,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.28":
-  version: 1.5.36
-  resolution: "electron-to-chromium@npm:1.5.36"
-  checksum: 10c0/cd8d0de7801107f2b2744b5b18641c969a49b0503996cc1a586bb79d893020d0c4e916ac1935603eea65104b4fc1096bc339e0151531dca9e0f0ce0c1882e2d8
+  version: 1.5.38
+  resolution: "electron-to-chromium@npm:1.5.38"
+  checksum: 10c0/f44715632fce33ac2444e5f0ac54684640b95bbfcdde47153e727645c33f5d18110d5af5348120a8345707c6c219d6109573b6acba56d819ca607010b75931ef
   languageName: node
   linkType: hard
 
@@ -873,11 +873,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.3.2":
-  version: 50.3.2
-  resolution: "eslint-plugin-jsdoc@npm:50.3.2"
+"eslint-plugin-jsdoc@npm:^50.4.1":
+  version: 50.4.1
+  resolution: "eslint-plugin-jsdoc@npm:50.4.1"
   dependencies:
-    "@es-joy/jsdoccomment": "npm:~0.48.0"
+    "@es-joy/jsdoccomment": "npm:~0.49.0"
     are-docs-informative: "npm:^0.0.2"
     comment-parser: "npm:1.4.1"
     debug: "npm:^4.3.6"
@@ -890,7 +890,7 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/4a649984e1a7dc957ccd71260a309d4a68e473cbac4de9268f11cbfc73e13fa4c2d1aa9ef4175962a1df2a396594a87a6ae4598452e9f36e23d9bcb47f0c4174
+  checksum: 10c0/d3b3947fc71acac2a790774729d96da4bd61dfc783558a998fca0b581b4dec059b5cdb048cd5873a8f188c5da1929307643909dd4f51063d2d6a00487b8b8940
   languageName: node
   linkType: hard
 
@@ -1952,16 +1952,16 @@ __metadata:
   linkType: hard
 
 "ts-pattern@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "ts-pattern@npm:5.4.0"
-  checksum: 10c0/8b7b785e51af736d110e181e8338fb74baafacf32f017b9df4f26bbefb295175f60d7cc22e23e77e9219930b2d3126aa1b0322bce210c9e18bede81cb4c2d2a5
+  version: 5.5.0
+  resolution: "ts-pattern@npm:5.5.0"
+  checksum: 10c0/4ae1fbeadcf193e72b27419d5fe71f559c100e45710eabf29e2ff3a8fa9ba29adfcd6d5d7d8169b95e2b264683a2eb8d94dbd3c893357b045b52b0c34c2b7c72
   languageName: node
   linkType: hard
 
 "tslib@npm:^2.6.2, tslib@npm:^2.6.3":
-  version: 2.7.0
-  resolution: "tslib@npm:2.7.0"
-  checksum: 10c0/469e1d5bf1af585742128827000711efa61010b699cb040ab1800bcd3ccdd37f63ec30642c9e07c4439c1db6e46345582614275daca3e0f4abae29b0083f04a6
+  version: 2.8.0
+  resolution: "tslib@npm:2.8.0"
+  checksum: 10c0/31e4d14dc1355e9b89e4d3c893a18abb7f90b6886b089c2da91224d0a7752c79f3ddc41bc1aa0a588ac895bd97bb99c5bc2bfdb2f86de849f31caeb3ba79bbe5
   languageName: node
   linkType: hard
 
@@ -1974,17 +1974,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.8.1":
-  version: 8.8.1
-  resolution: "typescript-eslint@npm:8.8.1"
+"typescript-eslint@npm:^8.9.0":
+  version: 8.9.0
+  resolution: "typescript-eslint@npm:8.9.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.8.1"
-    "@typescript-eslint/parser": "npm:8.8.1"
-    "@typescript-eslint/utils": "npm:8.8.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.9.0"
+    "@typescript-eslint/parser": "npm:8.9.0"
+    "@typescript-eslint/utils": "npm:8.9.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/d6793697fce239ef8838ced6e1e59940c30579c8f62c49bc605fdeda9f3f7a5c24bfddd997b142f8c411859dc0b9985ecdae569814dd4f8e6775e1899d55e9cc
+  checksum: 10c0/96bef4f5d1da9561078fa234642cfa2d024979917b8282b82f63956789bc566bdd5806ff2b414697f3dfdee314e9c9fec05911a7502550d763a496e2ef3af2fd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,60 +43,60 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/ast@npm:1.14.3"
+"@eslint-react/ast@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/ast@npm:1.15.0"
   dependencies:
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/typescript-estree": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/typescript-estree": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     birecord: "npm:^0.1.1"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.4.0"
-  checksum: 10c0/f77925cc00e5fa53bc69ee617bdc735453453a7f79b71a2ed3cdb10e4473582b80d9fdccb79230bc6ab308b5bd005cda631bc93dbe9f94c70b20a55afa881e57
+  checksum: 10c0/eac0df25b652723e7727559e0bff02b1378473b2c2e8a60eac69e349e04b36bf4baf28b0c698ac4c90981ebd849864b8c5f29484a1110a5ae71e3d6102fd1e93
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/core@npm:1.14.3"
+"@eslint-react/core@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/core@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/jsx": "npm:1.14.3"
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@eslint-react/var": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/type-utils": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/jsx": "npm:1.15.0"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@eslint-react/var": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/type-utils": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     birecord: "npm:^0.1.1"
     short-unique-id: "npm:^5.2.0"
     ts-pattern: "npm:^5.4.0"
-  checksum: 10c0/c5816833c03f6bfc246e6a6306758bf84b57e7058898485c4c01c86f87ba6b4c1e67000ab3acdcd6fc4402f5c1b197f1d7398500039be494c426808f383ea7c5
+  checksum: 10c0/42b81bd45f54a42e4e39483eae716b3f577cf1ffe59b6a2627bcaaf983fecdcc6dfbf383d53be31eb2cdf462ebac03d38617dc4aee7a8f180fc4d8c2249d1dad
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/eslint-plugin@npm:1.14.3"
+"@eslint-react/eslint-plugin@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/eslint-plugin@npm:1.15.0"
   dependencies:
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/type-utils": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
-    eslint-plugin-react-debug: "npm:1.14.3"
-    eslint-plugin-react-dom: "npm:1.14.3"
-    eslint-plugin-react-hooks-extra: "npm:1.14.3"
-    eslint-plugin-react-naming-convention: "npm:1.14.3"
-    eslint-plugin-react-web-api: "npm:1.14.3"
-    eslint-plugin-react-x: "npm:1.14.3"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/type-utils": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
+    eslint-plugin-react-debug: "npm:1.15.0"
+    eslint-plugin-react-dom: "npm:1.15.0"
+    eslint-plugin-react-hooks-extra: "npm:1.15.0"
+    eslint-plugin-react-naming-convention: "npm:1.15.0"
+    eslint-plugin-react-web-api: "npm:1.15.0"
+    eslint-plugin-react-x: "npm:1.15.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -105,67 +105,67 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/7be3acc35db72a0a08f2dea110221c03a8173e1c5c9563df8c3557f047e2111e2c0435ad1293d5ea44da709b2fe252320c3b93282fef7acdfbb4e0977a3acbbd
+  checksum: 10c0/b2518481f7c695088a36222a45ddadc809be155bcdb00c4255cdd574cba4b7d9ea20a959d9ce4db43c6f35b9f4993728be0defb138ec12920284602af62ab83f
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/jsx@npm:1.14.3"
+"@eslint-react/jsx@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/jsx@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@eslint-react/var": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@eslint-react/var": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     ts-pattern: "npm:^5.4.0"
-  checksum: 10c0/823141a2822b5d3be888ee3e69d57e40c132771b0ab727fb848ea2a7476435eb63347195ea28daece9f88a8c07af0783bb0bf4110515bbe273ed424084508045
+  checksum: 10c0/e54662a8045b7d8bf3483bb91879174b7e36dbba7f20f031c36262d685b1ad596c7f6d7294a0e9147199afc257cc895e2a50691181e7a5f2689e9ae1799896b3
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/shared@npm:1.14.3"
+"@eslint-react/shared@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/shared@npm:1.15.0"
   dependencies:
-    "@eslint-react/tools": "npm:1.14.3"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     picomatch: "npm:^4.0.2"
-  checksum: 10c0/912119c2923ceeab1b72e20244909791f2e7c8e16859f502f4e8c434b3697c05c67b4da2fb70dbd684f84883d2641715e1814ec5ca7431277ae462499c556290
+  checksum: 10c0/7bc3c66769bc8373211eb0ecad0d09de58e0c73acb74bce3094bd76b662223d1d7c4f38e3be7a3e3b40c0dc55ab3755599646e72c2820dccc944850e5d778701
   languageName: node
   linkType: hard
 
-"@eslint-react/tools@npm:1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/tools@npm:1.14.3"
-  checksum: 10c0/17051457fcf6fe7c5976568daf04b66cc4ae93c5bcaa3cf5898ce25ac6fc7aa31fad26d7b30f3dcb1cab0d2fc836783fb638fc0762cb556af89104cd51bb0955
+"@eslint-react/tools@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/tools@npm:1.15.0"
+  checksum: 10c0/76be10f6166ababb3f1747b371d5583c38db8004dab39a5be4af8ed8415f7d6b8d951f55af51f0f88ed4b4110c29bae404b80b793bd130f066140c32be5143a0
   languageName: node
   linkType: hard
 
-"@eslint-react/types@npm:1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/types@npm:1.14.3"
+"@eslint-react/types@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/types@npm:1.15.0"
   dependencies:
-    "@eslint-react/tools": "npm:1.14.3"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
-  checksum: 10c0/b0613c8a14f53d2468f8faa65b6f2f8c79490044bf1f8e5765f0f85e65ec100bd0a047a48d77ea4cadc89e5b9bb4f755668ddbe8832808a949730435d5ebeccb
+    "@eslint-react/tools": "npm:1.15.0"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
+  checksum: 10c0/6066d553a74daa58a308b32ce48e4df383e41fdd5df399626b56dd886a0eeb8bbc3a9c6d198c8596c03346d101636f37b6ca9491fadb09977b24f53bffe32214
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.14.3":
-  version: 1.14.3
-  resolution: "@eslint-react/var@npm:1.14.3"
+"@eslint-react/var@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@eslint-react/var@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     ts-pattern: "npm:^5.4.0"
-  checksum: 10c0/d867c755cfa6cbe0ea1bd880fb2460ee2e9a51caf6712c1c1d436572176873758b58a32ab844ee090a70c45d4ad0b4e0001db5ec8eb838e7c679d8ee8c85677c
+  checksum: 10c0/d85952cf41010655b27d2f8d021c2fd95cdd5b20da9072fbec740cbaff0d04819398b8732709cd295a376016e0978d1048d18452fd282e49a5945a326a603529
   languageName: node
   linkType: hard
 
@@ -314,7 +314,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.14.3"
+    "@eslint-react/eslint-plugin": "npm:^1.15.0"
     "@eslint/compat": "npm:^1.2.0"
     "@eslint/js": "npm:^9.12.0"
     "@tanstack/eslint-plugin-query": "npm:^5.59.7"
@@ -324,8 +324,8 @@ __metadata:
     eslint-import-resolver-typescript: "npm:^3.6.3"
     eslint-plugin-import-x: "npm:^4.3.1"
     eslint-plugin-jest-dom: "npm:^5.4.0"
-    eslint-plugin-jsdoc: "npm:^50.3.1"
-    eslint-plugin-react-hooks: "npm:5.1.0-rc-70fb1363-20241010"
+    eslint-plugin-jsdoc: "npm:^50.3.2"
+    eslint-plugin-react-hooks: "npm:5.0.0"
     eslint-plugin-react-refresh: "npm:^0.4.12"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     typescript: "npm:^5.6.3"
@@ -448,7 +448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.8.1, @typescript-eslint/scope-manager@npm:^8.7.0":
+"@typescript-eslint/scope-manager@npm:8.8.1, @typescript-eslint/scope-manager@npm:^8.8.1":
   version: 8.8.1
   resolution: "@typescript-eslint/scope-manager@npm:8.8.1"
   dependencies:
@@ -458,7 +458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.8.1, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.7.0":
+"@typescript-eslint/type-utils@npm:8.8.1, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.8.1":
   version: 8.8.1
   resolution: "@typescript-eslint/type-utils@npm:8.8.1"
   dependencies:
@@ -473,14 +473,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.8.1, @typescript-eslint/types@npm:^8.7.0":
+"@typescript-eslint/types@npm:8.8.1, @typescript-eslint/types@npm:^8.8.1":
   version: 8.8.1
   resolution: "@typescript-eslint/types@npm:8.8.1"
   checksum: 10c0/4b44857332a0b1bfafbeccb8be157f8266d9e226ac723f6af1272b9b670b49444423ddac733655163eb3b90e8c88393a68ab2d7f326f5775371eaf4b9ca31d7b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.8.1, @typescript-eslint/typescript-estree@npm:^8.7.0":
+"@typescript-eslint/typescript-estree@npm:8.8.1, @typescript-eslint/typescript-estree@npm:^8.8.1":
   version: 8.8.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.8.1"
   dependencies:
@@ -499,7 +499,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.8.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.3.0, @typescript-eslint/utils@npm:^8.7.0, @typescript-eslint/utils@npm:^8.8.1":
+"@typescript-eslint/utils@npm:8.8.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.3.0, @typescript-eslint/utils@npm:^8.8.1":
   version: 8.8.1
   resolution: "@typescript-eslint/utils@npm:8.8.1"
   dependencies:
@@ -873,9 +873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.3.1":
-  version: 50.3.1
-  resolution: "eslint-plugin-jsdoc@npm:50.3.1"
+"eslint-plugin-jsdoc@npm:^50.3.2":
+  version: 50.3.2
+  resolution: "eslint-plugin-jsdoc@npm:50.3.2"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.48.0"
     are-docs-informative: "npm:^0.0.2"
@@ -890,25 +890,25 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/b4e8d58f02794917581d74936e2af947aea3b518c4ad670866caa0b3f1f25cfec08414567c19d580a77d84431b2477f0a4075be500bb27b715013c59679f307e
+  checksum: 10c0/4a649984e1a7dc957ccd71260a309d4a68e473cbac4de9268f11cbfc73e13fa4c2d1aa9ef4175962a1df2a396594a87a6ae4598452e9f36e23d9bcb47f0c4174
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.14.3":
-  version: 1.14.3
-  resolution: "eslint-plugin-react-debug@npm:1.14.3"
+"eslint-plugin-react-debug@npm:1.15.0":
+  version: 1.15.0
+  resolution: "eslint-plugin-react-debug@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/core": "npm:1.14.3"
-    "@eslint-react/jsx": "npm:1.14.3"
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@eslint-react/var": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/type-utils": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/core": "npm:1.15.0"
+    "@eslint-react/jsx": "npm:1.15.0"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@eslint-react/var": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/type-utils": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.4.0"
   peerDependencies:
@@ -919,24 +919,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/3fdd7e2c4eff3f5e52394e6a7bba1e55982250e8e705bcaff8eba483ce306b4dee3fd5104508769f017f742ae80b27050ddad2fd4fd3e886dd9f25b68e90b485
+  checksum: 10c0/d45e490d3dd16290f2f8d820da1c891d6350ae05a1b942c3489dfdb6e14d8008e8eea167d9764ec1d56737ed066fdea01d7693ec5b25fc5b3792c77175286d45
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.14.3":
-  version: 1.14.3
-  resolution: "eslint-plugin-react-dom@npm:1.14.3"
+"eslint-plugin-react-dom@npm:1.15.0":
+  version: 1.15.0
+  resolution: "eslint-plugin-react-dom@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/core": "npm:1.14.3"
-    "@eslint-react/jsx": "npm:1.14.3"
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@eslint-react/var": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/core": "npm:1.15.0"
+    "@eslint-react/jsx": "npm:1.15.0"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@eslint-react/var": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
@@ -946,25 +946,25 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/dfbc8541ae94848f06ffbeb614472b0948208a683ae92a07f265c3ff305fc2c50257a3b96078a12a5c2827e887a4dec7cf0ed87aa465f030634ee47892a047d3
+  checksum: 10c0/b55811a8d70ed3dee154ab5559d10a6a04dc9c2ce32678f63c1822d9ed54838fb1df61d3854dc7f731ed2a896f48da114f067c41f2f2efaf50d51440c6c3e9b9
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.14.3":
-  version: 1.14.3
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.14.3"
+"eslint-plugin-react-hooks-extra@npm:1.15.0":
+  version: 1.15.0
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/core": "npm:1.14.3"
-    "@eslint-react/jsx": "npm:1.14.3"
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@eslint-react/var": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/type-utils": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/core": "npm:1.15.0"
+    "@eslint-react/jsx": "npm:1.15.0"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@eslint-react/var": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/type-utils": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
@@ -974,33 +974,33 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/6205e48224e9d5097eaabca9b364bdd69d0068b1783ee265f4caa511d319745dad3dc958dcb479b2c56624a34cc3f37e64e8699b9107b1c8e2ae05c8c2f44322
+  checksum: 10c0/d5e0c0404cbdbdd283ad728d2e1765cd8bdf8635b6beb07d2024d229460f69bab472a2792acfe7734437a9df4a2e93267c55535f6b9ebda244279f5cb9bbddea
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:5.1.0-rc-70fb1363-20241010":
-  version: 5.1.0-rc-70fb1363-20241010
-  resolution: "eslint-plugin-react-hooks@npm:5.1.0-rc-70fb1363-20241010"
+"eslint-plugin-react-hooks@npm:5.0.0":
+  version: 5.0.0
+  resolution: "eslint-plugin-react-hooks@npm:5.0.0"
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10c0/99d54a8bc6ba3e1f1c78bb89da8674bcdd70faa239118dd62419d1126d4e5c7a649d00588dc667a784632f9d70a825e7338dcf970f832b373fa4fd0d0749a5c8
+  checksum: 10c0/bcb74b421f32e4203a7100405b57aab85526be4461e5a1da01bc537969a30012d2ee209a2c2a6cac543833a27188ce1e6ad71e4628d0bb4a2e5365cad86c5002
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.14.3":
-  version: 1.14.3
-  resolution: "eslint-plugin-react-naming-convention@npm:1.14.3"
+"eslint-plugin-react-naming-convention@npm:1.15.0":
+  version: 1.15.0
+  resolution: "eslint-plugin-react-naming-convention@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/core": "npm:1.14.3"
-    "@eslint-react/jsx": "npm:1.14.3"
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/type-utils": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/core": "npm:1.15.0"
+    "@eslint-react/jsx": "npm:1.15.0"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/type-utils": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     ts-pattern: "npm:^5.4.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
@@ -1010,7 +1010,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/63cf167a5e483143d6d3ccd5e54530f154f5c61a6672116b5d30e075c8e732668b1876c448eaebf5ca5038d22c59c2fd51276b2e53e842f7fbc6695fce78f827
+  checksum: 10c0/bf1366472f3a589a4f83ab64096357d97d2ed0b3da96980a727c7e976204cda93f39528f2d75722d211b12658e28d8a174e18d52275f99d11e2c975c420d3249
   languageName: node
   linkType: hard
 
@@ -1023,20 +1023,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.14.3":
-  version: 1.14.3
-  resolution: "eslint-plugin-react-web-api@npm:1.14.3"
+"eslint-plugin-react-web-api@npm:1.15.0":
+  version: 1.15.0
+  resolution: "eslint-plugin-react-web-api@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/core": "npm:1.14.3"
-    "@eslint-react/jsx": "npm:1.14.3"
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@eslint-react/var": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/core": "npm:1.15.0"
+    "@eslint-react/jsx": "npm:1.15.0"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@eslint-react/var": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.4.0"
   peerDependencies:
@@ -1047,25 +1047,25 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/d3642050679ecb0c9d1aa37772eb147afae48b8aa4c20bc16b7b1f0e500303d15ec03014d8338bbdf6afd2b9811c52880e3202b65cd59322f791be487aeb1d94
+  checksum: 10c0/68228cf4b5a6ac9d53dc005de93a14a98dad387e664fb0971bbf7866349a6d2d13fe575071fbae50c134943946f572add7fdfb633c3dd59264017418e6a49b60
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.14.3":
-  version: 1.14.3
-  resolution: "eslint-plugin-react-x@npm:1.14.3"
+"eslint-plugin-react-x@npm:1.15.0":
+  version: 1.15.0
+  resolution: "eslint-plugin-react-x@npm:1.15.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.14.3"
-    "@eslint-react/core": "npm:1.14.3"
-    "@eslint-react/jsx": "npm:1.14.3"
-    "@eslint-react/shared": "npm:1.14.3"
-    "@eslint-react/tools": "npm:1.14.3"
-    "@eslint-react/types": "npm:1.14.3"
-    "@eslint-react/var": "npm:1.14.3"
-    "@typescript-eslint/scope-manager": "npm:^8.7.0"
-    "@typescript-eslint/type-utils": "npm:^8.7.0"
-    "@typescript-eslint/types": "npm:^8.7.0"
-    "@typescript-eslint/utils": "npm:^8.7.0"
+    "@eslint-react/ast": "npm:1.15.0"
+    "@eslint-react/core": "npm:1.15.0"
+    "@eslint-react/jsx": "npm:1.15.0"
+    "@eslint-react/shared": "npm:1.15.0"
+    "@eslint-react/tools": "npm:1.15.0"
+    "@eslint-react/types": "npm:1.15.0"
+    "@eslint-react/var": "npm:1.15.0"
+    "@typescript-eslint/scope-manager": "npm:^8.8.1"
+    "@typescript-eslint/type-utils": "npm:^8.8.1"
+    "@typescript-eslint/types": "npm:^8.8.1"
+    "@typescript-eslint/utils": "npm:^8.8.1"
     is-immutable-type: "npm:5.0.0"
     ts-pattern: "npm:^5.4.0"
   peerDependencies:
@@ -1076,7 +1076,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/35cca09d456d5863ba0e8c6384fd04beb12aff12710633e088ea313b24dc1b4ba1e91e4aaa1c0ae53a88b64b10c9acc68ac1e4c1194f541bdc84461f2018c9b0
+  checksum: 10c0/c071e1f1f44038b5b77d4291ca82afc9e3db47d36727fa59498b688e96bba5406eb0465dfb3149564221f379c0c0ee50a3b40200f4d9b10966d42ed9c30c660a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `@eslint-react/eslint-plugin`
    - [1.14.2](https://github.com/Rel1cx/eslint-react/releases/tag/v1.14.2)
    - [1.14.3](https://github.com/Rel1cx/eslint-react/releases/tag/v1.14.3)
    - [1.15.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.15.0)
- `@tanstack/eslint-plugin-query`
    - [5.57.0](https://github.com/TanStack/query/releases/tag/v5.57.0)
    - [5.57.1](https://github.com/TanStack/query/releases/tag/v5.57.1)
    - [5.57.2](https://github.com/TanStack/query/releases/tag/v5.57.2)
    - [5.58.1](https://github.com/TanStack/query/releases/tag/v5.58.1)
    - [5.59.1](https://github.com/TanStack/query/releases/tag/v5.59.1)
    - [5.59.2](https://github.com/TanStack/query/releases/tag/v5.59.2)
    - [5.59.4](https://github.com/TanStack/query/releases/tag/v5.59.4)
    - [5.59.7](https://github.com/TanStack/query/releases/tag/v5.59.7)
- `@vitest/eslint-plugin`
    - [1.1.5](https://github.com/vitest-dev/eslint-plugin-vitest/releases/tag/v1.1.5)
    - [1.1.6](https://github.com/vitest-dev/eslint-plugin-vitest/releases/tag/v1.1.6)
    - [1.1.7](https://github.com/vitest-dev/eslint-plugin-vitest/releases/tag/v1.1.7)
- `eslint`
    - [9.11.0](https://github.com/eslint/eslint/releases/tag/v9.11.0)
    - [9.11.1](https://github.com/eslint/eslint/releases/tag/v9.11.1)
    - [9.12.0](https://github.com/eslint/eslint/releases/tag/v9.12.0)
- `eslint-plugin-import-x`
    - [4.3.0](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.3.0)
    - [4.3.1](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.3.1)
- `eslint-plugin-jsdoc`
    - [50.2.4](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.2.4)
    - [50.2.5](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.2.5)
    - [50.3.0](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.3.0)
    - [50.3.1](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.3.1)
    - [50.3.2](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.3.2)
    - [50.4.0](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.4.0)
    - [50.4.1](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.4.1)
- `eslint-plugin-react-hooks`
    - [5.0.0](https://github.com/facebook/react/releases/tag/eslint-plugin-react-hooks%405.0.0)
- `typescript-eslint`
    - [8.7.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.7.0)
    - [8.8.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.8.0)
    - [8.8.1](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.8.1)
    - [8.9.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.9.0)