### PR TITLE
Add support for strict TypeScript rules (opt-out, enabled by default)

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,7 +9,7 @@ Add the following to your `package.json`:
 ```jsonc
 {
   "devDependencies": {
-    "@pandell/eslint-config": "^9.7.0",
+    "@pandell/eslint-config": "^9.7.1",
     "eslint": "^9.18.0",
     // ...
   },
@@ -29,9 +29,13 @@ in `node_modules/@pandell/eslint-config/dist/pandellEsLintConfig.d.ts`). Example
 import { createPandellEsLintConfig } from "@pandell/eslint-config";
 
 export default createPandellEsLintConfig({
-    // type-checked typescript is enabled by default; to disable type-checking
-    // rules, uncomment the following line:
-    // typeScript: { typeChecked: false },
+    typescript: {
+        // type-checked typescript is enabled by default; uncomment the following line to disable:
+        // typeChecked: false,
+
+        // strict typescript is enabled by default; uncomment the following line to disable:
+        // strict: false,
+    }
     react: { enabled: true },
     vite: { enabled: true },
     testing: { enabledJsDom: true, enabledTestingLibrary: true },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@eslint-react/eslint-plugin": "^1.23.2",
-    "@eslint/compat": "^1.2.5",
     "@eslint/js": "^9.18.0",
     "@tanstack/eslint-plugin-query": "^5.62.16",
     "@typescript-eslint/utils": "^8.20.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/eslint-config",
   "type": "module",
-  "version": "9.7.0",
+  "version": "9.7.1",
   "description": "Pandell ESLint shared config",
   "keywords": [
     "eslint",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",
-    "eslint-plugin-jsdoc": "^50.6.1",
+    "eslint-plugin-jsdoc": "^50.6.2",
     "eslint-plugin-react-hooks": "5.1.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -104,6 +104,7 @@ async function createPandellTypeScriptConfig(
     noExplicitAny = "error",
     preferNullishCoalescing = "off",
     parserOptions = { project: true },
+    strict = true,
     typeChecked = true,
   } = typeScript;
 
@@ -114,11 +115,15 @@ async function createPandellTypeScriptConfig(
   const esLintTs = await import("typescript-eslint");
   const resolvedFiles = files === "do not set" ? undefined : files;
   const recommendedConfig = typeChecked
-    ? esLintTs.configs.recommendedTypeChecked
-    : esLintTs.configs.recommended;
+    ? strict
+      ? esLintTs.configs.strictTypeChecked
+      : esLintTs.configs.recommendedTypeChecked
+    : strict
+      ? esLintTs.configs.strict
+      : esLintTs.configs.recommended;
 
   return esLintTs.config({
-    name: `@pandell-eslint-config/typescript${typeChecked ? "-type-checked" : ""}`,
+    name: `@pandell-eslint-config/typescript${strict ? "-strict" : ""}${typeChecked ? "-type-checked" : ""}`,
     extends: [
       ...recommendedConfig,
       {
@@ -603,6 +608,15 @@ export interface PandellEsLintConfigSettings {
      * @default {project:true}
      */
     readonly parserOptions?: TSESLint.ParserOptions;
+
+    /**
+     * Should the TypeScript configuration include strict rules?
+     * Strict rules contain all recommended rules, but add opinionated extra
+     * rules that can catch some bugs.
+     *
+     * @default true
+     */
+    readonly strict?: boolean;
 
     /**
      * Should the TypeScript configuration include type-checked rules?

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -304,13 +304,12 @@ async function createPandellTestingConfig(
 
   const resolvedFiles = files === "do not set" ? undefined : files;
   const configs = [] as Linter.Config[];
-  const [jestDom, testingLibrary, testingLibraryCompat, vitest] = await Promise.all([
+  const [jestDom, testingLibrary, vitest] = await Promise.all([
     enabledTestingLibrary ? import("eslint-plugin-jest-dom") : null,
     enabledTestingLibrary ? import("eslint-plugin-testing-library") : null,
-    enabledTestingLibrary ? import("@eslint/compat") : null,
     enabledVitest ? import("@vitest/eslint-plugin") : null,
   ]);
-  if (jestDom && testingLibrary && testingLibraryCompat) {
+  if (jestDom && testingLibrary) {
     configs.push(
       {
         ...jestDom.default.configs["flat/recommended"],

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -311,7 +311,6 @@ async function createPandellTestingConfig(
     enabledVitest ? import("@vitest/eslint-plugin") : null,
   ]);
   if (jestDom && testingLibrary && testingLibraryCompat) {
-    const testingLibraryReactFlatConfig = testingLibrary.default.configs["flat/react"];
     configs.push(
       {
         ...jestDom.default.configs["flat/recommended"],
@@ -319,16 +318,8 @@ async function createPandellTestingConfig(
         files: resolvedFiles,
       },
       {
-        ...testingLibraryReactFlatConfig,
+        ...testingLibrary.default.configs["flat/react"],
         name: "testing-library/react",
-        // 2024-09-05, milang: eslint-plugin-testing-library currently does not support
-        // ESLint 9 API; we have to use an adapter for the time being, see
-        // https://github.com/testing-library/eslint-plugin-testing-library/issues/899#issuecomment-2121272355
-        plugins: {
-          "testing-library": testingLibraryCompat.fixupPluginRules(
-            testingLibraryReactFlatConfig.plugins!["testing-library"],
-          ),
-        },
         files: resolvedFiles,
       },
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,7 @@ __metadata:
     eslint-import-resolver-typescript: "npm:^3.7.0"
     eslint-plugin-import-x: "npm:^4.6.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
-    eslint-plugin-jsdoc: "npm:^50.6.1"
+    eslint-plugin-jsdoc: "npm:^50.6.2"
     eslint-plugin-react-hooks: "npm:5.1.0"
     eslint-plugin-react-refresh: "npm:^0.4.18"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
@@ -861,9 +861,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.6.1":
-  version: 50.6.1
-  resolution: "eslint-plugin-jsdoc@npm:50.6.1"
+"eslint-plugin-jsdoc@npm:^50.6.2":
+  version: 50.6.2
+  resolution: "eslint-plugin-jsdoc@npm:50.6.2"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.49.0"
     are-docs-informative: "npm:^0.0.2"
@@ -878,7 +878,7 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/0117fa0ce0d0e0cd7fb43d207f421ab7ecf6e65c09648442db577794f36b85256f393adef4bf3e586cb7e5ab068073600808c823c60cc69c4aea662d7c931324
+  checksum: 10c0/7349681c33c1a37e8e635b8b354e1ac3f13b348cbdaf8e9b2db878601976d29cb9b2359156e4176ed66b65d10fb237fc6eb2a921512b9fedd811ed6d1a95b445
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,18 +168,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "@eslint/compat@npm:1.2.5"
-  peerDependencies:
-    eslint: ^9.10.0
-  peerDependenciesMeta:
-    eslint:
-      optional: true
-  checksum: 10c0/c7cd6c623b850e7507fdaf26298b42b07012a65b57f6abbdd1e968eb281756bb94024f162a661ffcc7ad8b2949832aec5078a9fdefa87081e127d392842d0048
-  languageName: node
-  linkType: hard
-
 "@eslint/config-array@npm:^0.19.0":
   version: 0.19.0
   resolution: "@eslint/config-array@npm:0.19.0"
@@ -324,7 +312,6 @@ __metadata:
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@eslint-react/eslint-plugin": "npm:^1.23.2"
-    "@eslint/compat": "npm:^1.2.5"
     "@eslint/js": "npm:^9.18.0"
     "@tanstack/eslint-plugin-query": "npm:^5.62.16"
     "@typescript-eslint/utils": "npm:^8.20.0"


### PR DESCRIPTION
Most of the strict (and type-checked) rules in `typescript-eslint` plugin make sense for us, so I enabled them by default in this PR and added a flag that can disable them, switching back to the recommended (and type-checked) rules.

List of `strict-type-checked` rules:
https://typescript-eslint.io/rules/?=strict

Description of `strict-type-checked` rules:
https://typescript-eslint.io/users/configs/#strict-type-checked

Note that `typescript-eslint` team has the following tip on the description page, but this shouldn't be an issue for Pandell teams:

> [!TIP]
> We recommend a TypeScript project extend from plugin:@typescript-eslint/strict-type-checked only if a nontrivial percentage of its developers are highly proficient in TypeScript.

---

- `eslint-plugin-jsdoc`
    - [50.6.2](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.2)
