### PR TITLE
@pandell/eslint-config: eslint 9.19, typescript-eslint 8.22, other NPM updates as of 2025-01-31

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,11 @@
     "prettier": "^3.4.2",
     "typescript": "^5.7.3"
   },
+  "eslint-formatter-teamcity": {
+    "error-statistics-name": "ESLint Error Count",
+    "report-name": "ESLint Violations",
+    "reporter": "inspections",
+    "warning-statistics-name": "ESLint Warning Count"
+  },
   "prettier": "@pandell/prettier-config"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@pandell/eslint-config": "workspace:packages/eslint-config",
     "browserslist": "^4.24.4",
-    "eslint": "^9.18.0",
+    "eslint": "^9.19.0",
     "eslint-formatter-teamcity": "^1.0.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.3"

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,8 +9,8 @@ Add the following to your `package.json`:
 ```jsonc
 {
   "devDependencies": {
-    "@pandell/eslint-config": "^9.8.0",
-    "eslint": "^9.18.0",
+    "@pandell/eslint-config": "^9.9.0",
+    "eslint": "^9.19.0",
     // ...
   },
   // ...

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/eslint-config",
   "type": "module",
-  "version": "9.8.0",
+  "version": "9.9.0",
   "description": "Pandell ESLint shared config",
   "keywords": [
     "eslint",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,23 +25,23 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.24.1",
-    "@eslint/js": "^9.18.0",
-    "@tanstack/eslint-plugin-query": "^5.64.2",
-    "@typescript-eslint/utils": "^8.21.0",
+    "@eslint-react/eslint-plugin": "^1.26.0",
+    "@eslint/js": "^9.19.0",
+    "@tanstack/eslint-plugin-query": "^5.66.0",
+    "@typescript-eslint/utils": "^8.22.0",
     "@vitest/eslint-plugin": "^1.1.25",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",
-    "eslint-plugin-jsdoc": "^50.6.2",
+    "eslint-plugin-jsdoc": "^50.6.3",
     "eslint-plugin-react-hooks": "5.1.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-testing-library": "^7.1.1",
-    "typescript-eslint": "^8.21.0"
+    "typescript-eslint": "^8.22.0"
   },
   "devDependencies": {
-    "eslint": "^9.18.0",
+    "eslint": "^9.19.0",
     "typescript": "^5.7.3"
   },
   "peerDependencies": {

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -181,6 +181,8 @@ async function createPandellTypeScriptConfig(
       "@typescript-eslint/no-shadow": ["error", { ignoreTypeValueShadow: true }], // the typescript-eslint version of "no-shadow" uses TypeScript's scope analysis, which reduces false positives that were likely when using the default ESLint version
 
       ...(typeChecked && {
+        "@typescript-eslint/consistent-type-exports": "warn",
+        "@typescript-eslint/consistent-type-imports": "warn",
         "@typescript-eslint/no-deprecated": "error",
         "@typescript-eslint/prefer-nullish-coalescing": preferNullishCoalescing,
         "@typescript-eslint/prefer-readonly": "warn",

--- a/packages/eslint-config/typings/react.d.ts
+++ b/packages/eslint-config/typings/react.d.ts
@@ -1,5 +1,5 @@
 declare module "eslint-plugin-react-hooks" {
-  import { ESLint } from "eslint";
+  import type { ESLint } from "eslint";
 
   export const configs: {
     recommended: {

--- a/packages/eslint-config/typings/testing.d.ts
+++ b/packages/eslint-config/typings/testing.d.ts
@@ -1,7 +1,7 @@
 // spell-checker:word marko
 
 declare module "eslint-plugin-testing-library" {
-  import { ESLint, Linter } from "eslint";
+  import type { ESLint, Linter } from "eslint";
 
   const plugin: {
     configs: {
@@ -23,7 +23,7 @@ declare module "eslint-plugin-testing-library" {
 }
 
 declare module "eslint-plugin-jest-dom" {
-  import { ESLint, Linter } from "eslint";
+  import type { ESLint, Linter } from "eslint";
 
   const plugin: {
     configs: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,62 +43,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.24.1":
-  version: 1.24.1
-  resolution: "@eslint-react/ast@npm:1.24.1"
+"@eslint-react/ast@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@eslint-react/ast@npm:1.26.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.24.1"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/typescript-estree": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/typescript-estree": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/64a8ad2dfed39f6d713da1afc0361a4f5be84bae3c03a6b3cb25fd2c75a00d3e024c1e2c6ef506c896f05b4b5596e9911af33461835fe85e3a49d87d3899977d
+  checksum: 10c0/0f2c0387cf2ac4b4199adee98062e1f9bde8b277cd223006ac7b51d809fa014173a021560536781a421a79be7c121ba53dbcb4980d5eb43fbbd7a0f9271f1b45
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.24.1":
-  version: 1.24.1
-  resolution: "@eslint-react/core@npm:1.24.1"
+"@eslint-react/core@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@eslint-react/core@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/jsx": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@eslint-react/var": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/type-utils": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/jsx": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@eslint-react/var": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/type-utils": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/11c664b25af891d16bf569098935c3306c675446797d67a5cd98875761bcafba9034c8470d73f020381582279a7614980250298bb5eb9fbaaef713f28b99e6bc
+  checksum: 10c0/c38f392d52ec61df0a56f3be48df2b0bece3a28baf8e2ec29db05da0faff7bc1e99effd1a7ced1476299b0aa8a5351d728f9ba24b4912ab343fe3a5f66fcf9f9
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.24.1":
-  version: 1.24.1
-  resolution: "@eslint-react/eff@npm:1.24.1"
-  checksum: 10c0/e057474b1880322332ee20785782394284bbae32f1e05af51f552ad3bf8d2dd4dd89c86b698dbf727c78d81bda98cf8032f059476562508a370f3d0666ab9539
+"@eslint-react/eff@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@eslint-react/eff@npm:1.26.0"
+  checksum: 10c0/480ea69040c3a7be93ef0cb12f61a258accff833be65f349c2835a000cccedfc4363922663893318a6f2e57f834bcc4d56e9115ca30454dcd928f34f0cba19c8
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.24.1":
-  version: 1.24.1
-  resolution: "@eslint-react/eslint-plugin@npm:1.24.1"
+"@eslint-react/eslint-plugin@npm:^1.26.0":
+  version: 1.26.0
+  resolution: "@eslint-react/eslint-plugin@npm:1.26.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/type-utils": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
-    eslint-plugin-react-debug: "npm:1.24.1"
-    eslint-plugin-react-dom: "npm:1.24.1"
-    eslint-plugin-react-hooks-extra: "npm:1.24.1"
-    eslint-plugin-react-naming-convention: "npm:1.24.1"
-    eslint-plugin-react-web-api: "npm:1.24.1"
-    eslint-plugin-react-x: "npm:1.24.1"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/type-utils": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
+    eslint-plugin-react-debug: "npm:1.26.0"
+    eslint-plugin-react-dom: "npm:1.26.0"
+    eslint-plugin-react-hooks-extra: "npm:1.26.0"
+    eslint-plugin-react-naming-convention: "npm:1.26.0"
+    eslint-plugin-react-web-api: "npm:1.26.0"
+    eslint-plugin-react-x: "npm:1.26.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -107,49 +107,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/a4472db6f2d705e5bf9b8a6dad2ac05461f0473360adf09457573faa97048502862b890658f7029a3e16fa2343808e57bb5464c98b3296aa8e88a3fef3cb2ee0
+  checksum: 10c0/e1ea957d9d9b8241e4ed90fc3900e957d3d76902ae130b8d5b80b544953093561cf27786f3d3f6f9d22f21f49dd6fa379afd32886723c53d31118c80033923c9
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.24.1":
-  version: 1.24.1
-  resolution: "@eslint-react/jsx@npm:1.24.1"
+"@eslint-react/jsx@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@eslint-react/jsx@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/var": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/var": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/c1fb799410166fef402b391c2f2e951b247f0b9974de9fe3ff4fa587264f63e69ba38c153889768c122780f8f22b2e2e8cc72fc7d672e0dcbcbf6b825b2e23dc
+  checksum: 10c0/42685bd40ae11aca13f83f37fa3f80575b96069ae103d9e23d61878f3426b531de675cadb9dd901e7cc20e9c2b7a245b86e863b26c2d7127f254d1cd1f00cb68
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.24.1":
-  version: 1.24.1
-  resolution: "@eslint-react/shared@npm:1.24.1"
+"@eslint-react/shared@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@eslint-react/shared@npm:1.26.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.24.1"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/d4966b0143232ca44118fa420ad98d511cd974dee8e8fd5a97bfbc05fa3ed4d7d5573e50377a61336979283f84bef6331968eebd438435811f76f8b2e2589231
+  checksum: 10c0/43f4e38a06a3b4485bd20c2ab360f5b978b43a5b432a74ef525e8a0c51e551b1f9f9e6578c3de998874f2d1f8d56210af8feed8c95f8134da51b9ca0d6b07665
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.24.1":
-  version: 1.24.1
-  resolution: "@eslint-react/var@npm:1.24.1"
+"@eslint-react/var@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@eslint-react/var@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/b8a3c62c39513513eb24932e4ef88878731faace69de866dffeec386abf7091726f367d673d9056ac5fd622c231e0eaeacfcf0b68905e8686a4542043c56cada
+  checksum: 10c0/e2a8292ce2e0c1813ff7e4173abbe43216434ed63aff231a8c98b62675c3ebdabddaf5ca3399fac5f8e5cb543eb5522bcb7480b2a31ae635cbc1b8cd41d3c1a2
   languageName: node
   linkType: hard
 
@@ -190,10 +190,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.18.0, @eslint/js@npm:^9.18.0":
-  version: 9.18.0
-  resolution: "@eslint/js@npm:9.18.0"
-  checksum: 10c0/3938344c5ac7feef4b73fcb30f3c3e753570cea74c24904bb5d07e9c42fcd34fcbc40f545b081356a299e11f360c9c274b348c05fb0113fc3d492e5175eee140
+"@eslint/js@npm:9.19.0, @eslint/js@npm:^9.19.0":
+  version: 9.19.0
+  resolution: "@eslint/js@npm:9.19.0"
+  checksum: 10c0/45dc544c8803984f80a438b47a8e578fae4f6e15bc8478a703827aaf05e21380b42a43560374ce4dad0d5cb6349e17430fc9ce1686fed2efe5d1ff117939ff90
   languageName: node
   linkType: hard
 
@@ -296,22 +296,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.24.1"
-    "@eslint/js": "npm:^9.18.0"
-    "@tanstack/eslint-plugin-query": "npm:^5.64.2"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/eslint-plugin": "npm:^1.26.0"
+    "@eslint/js": "npm:^9.19.0"
+    "@tanstack/eslint-plugin-query": "npm:^5.66.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     "@vitest/eslint-plugin": "npm:^1.1.25"
-    eslint: "npm:^9.18.0"
+    eslint: "npm:^9.19.0"
     eslint-import-resolver-typescript: "npm:^3.7.0"
     eslint-plugin-import-x: "npm:^4.6.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
-    eslint-plugin-jsdoc: "npm:^50.6.2"
+    eslint-plugin-jsdoc: "npm:^50.6.3"
     eslint-plugin-react-hooks: "npm:5.1.0"
     eslint-plugin-react-refresh: "npm:^0.4.18"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     eslint-plugin-testing-library: "npm:^7.1.1"
     typescript: "npm:^5.7.3"
-    typescript-eslint: "npm:^8.21.0"
+    typescript-eslint: "npm:^8.22.0"
   peerDependencies:
     eslint: ">= 9"
     typescript: ">= 5"
@@ -361,14 +361,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/eslint-plugin-query@npm:^5.64.2":
-  version: 5.64.2
-  resolution: "@tanstack/eslint-plugin-query@npm:5.64.2"
+"@tanstack/eslint-plugin-query@npm:^5.66.0":
+  version: 5.66.0
+  resolution: "@tanstack/eslint-plugin-query@npm:5.66.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.18.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/bea224b561d3c5b4dd8cb493981449f9bf505a2ebcf20112259075b82f92ba93a3b17adeb8e703b758c8173406364562997e12786d70571ce5e05f011fb57ed2
+  checksum: 10c0/e0dbd4a457fc6048e85f87817b20b84934722e7467237d881439cf446bc92f0cc9dfd4e6cf1d8ec5b25eb3cecfe5fd808d87ecd8269aa132cb5725473c7603a6
   languageName: node
   linkType: hard
 
@@ -393,15 +393,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.21.0"
+"@typescript-eslint/eslint-plugin@npm:8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.22.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.21.0"
-    "@typescript-eslint/type-utils": "npm:8.21.0"
-    "@typescript-eslint/utils": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
+    "@typescript-eslint/scope-manager": "npm:8.22.0"
+    "@typescript-eslint/type-utils": "npm:8.22.0"
+    "@typescript-eslint/utils": "npm:8.22.0"
+    "@typescript-eslint/visitor-keys": "npm:8.22.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -410,64 +410,64 @@ __metadata:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/4601d21ec35b9fa5cfc1ad0330733ab40d6c6822c7fc15c3584a16f678c9a72e077a1725a950823fe0f499a15f3981795b1ea5d1e7a1be5c7b8296ea9ae6327c
+  checksum: 10c0/eecc23e05287cc99a43855d64c0f0898f690ee14b8c31b60ba92ce9732443f6b0c9695514b276fb2ecd27e64c15d4c38cd28b570779115525b4dfdbba60e81ca
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/parser@npm:8.21.0"
+"@typescript-eslint/parser@npm:8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/parser@npm:8.22.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.21.0"
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/typescript-estree": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
+    "@typescript-eslint/scope-manager": "npm:8.22.0"
+    "@typescript-eslint/types": "npm:8.22.0"
+    "@typescript-eslint/typescript-estree": "npm:8.22.0"
+    "@typescript-eslint/visitor-keys": "npm:8.22.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/aadebd50ca7aa2d61ad85d890c0d7010f2c293ec4d50a7833ef9674f232f0bc7118faa93a898771fbea50f02d542d687cf3569421b23f72fe6fed6895d5506fc
+  checksum: 10c0/6575684d4724aa908b0d6a29db5d5054b9277804844ee4179c77371f8b8b84534b9b7e4df0e282c5f39729ae6f0019208a6b83f0ca5d0f06f9da5a06d8ddb4fd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.21.0, @typescript-eslint/scope-manager@npm:^8.1.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.21.0"
+"@typescript-eslint/scope-manager@npm:8.22.0, @typescript-eslint/scope-manager@npm:^8.1.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.22.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
-  checksum: 10c0/ea405e79dc884ea1c76465604db52f9b0941d6cbb0bde6bce1af689ef212f782e214de69d46503c7c47bfc180d763369b7433f1965e3be3c442b417e8c9f8f75
+    "@typescript-eslint/types": "npm:8.22.0"
+    "@typescript-eslint/visitor-keys": "npm:8.22.0"
+  checksum: 10c0/f393ab32086f4b095fcd77169abb5200ad94f282860944d164cec8c9b70090c36235f49b066ba24dfd953201b7730e48200a254e5950a9a3565acdacbbc0fd64
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.21.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/type-utils@npm:8.21.0"
+"@typescript-eslint/type-utils@npm:8.22.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/type-utils@npm:8.22.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.21.0"
-    "@typescript-eslint/utils": "npm:8.21.0"
+    "@typescript-eslint/typescript-estree": "npm:8.22.0"
+    "@typescript-eslint/utils": "npm:8.22.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/617f5dfe83fd9a7c722b27fa4e7f0c84f29baa94f75a4e8e5ccfd5b0a373437f65724e21b9642870fb0960f204b1a7f516a038200a12f8118f21b1bf86315bf3
+  checksum: 10c0/dc457d9184dc2156eda225c63de03b1052d75464d6393edaf0f1728eecf64170f73e19bc9b9d4a4a029870ce25015b59bd6705e1e18b731ca4fcecac4398bfb7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.21.0, @typescript-eslint/types@npm:^8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/types@npm:8.21.0"
-  checksum: 10c0/67dfd300cc614d7b02e94d0dacfb228a7f4c3fd4eede29c43adb9e9fcc16365ae3df8d6165018da3c123dce65545bef03e3e8183f35e9b3a911ffc727e3274c2
+"@typescript-eslint/types@npm:8.22.0, @typescript-eslint/types@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/types@npm:8.22.0"
+  checksum: 10c0/6357d0937e2b84ddb00763d05053fe50f2270fa428aa11f1ad6a1293827cf54da7e6d4d20b00b9d4f633b6982a2eb0e494f05285daa1279d8a3493f0d8abae18
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.21.0, @typescript-eslint/typescript-estree@npm:^8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.21.0"
+"@typescript-eslint/typescript-estree@npm:8.22.0, @typescript-eslint/typescript-estree@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.22.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
+    "@typescript-eslint/types": "npm:8.22.0"
+    "@typescript-eslint/visitor-keys": "npm:8.22.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -476,32 +476,32 @@ __metadata:
     ts-api-utils: "npm:^2.0.0"
   peerDependencies:
     typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/0cf5b0382524f4af54fb5ec71ca7e939ec922711f2d77b383740b28dd4b21407b0ab5dded62df6819d01c12c0b354e95667e3c7025a5d27d05b805161ab94855
+  checksum: 10c0/0a9d77fbadfb1e54c06abde424e461103576595c70e50ae8a15a3d7c07f125f253f505208e1ea5cc483b9073d95fc10ce0c4ddfe0fe08ec2aceda6314c341e0d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.21.0, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/utils@npm:8.21.0"
+"@typescript-eslint/utils@npm:8.22.0, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/utils@npm:8.22.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.21.0"
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/typescript-estree": "npm:8.21.0"
+    "@typescript-eslint/scope-manager": "npm:8.22.0"
+    "@typescript-eslint/types": "npm:8.22.0"
+    "@typescript-eslint/typescript-estree": "npm:8.22.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/d8347dbe9176417220aa62902cfc1b2007a9246bb7a8cccdf8590120903eb50ca14cb668efaab4646d086277f2367559985b62230e43ebd8b0723d237eeaa2f2
+  checksum: 10c0/6f1e3f9c0fb865c8cef4fdca04679cea7357ed011338b54d80550e9ad5369a3f24cbe4b0985d293192fe351fa133e5f4ea401f47af90bb46c21903bfe087b398
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.21.0"
+"@typescript-eslint/visitor-keys@npm:8.22.0":
+  version: 8.22.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.22.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.21.0"
+    "@typescript-eslint/types": "npm:8.22.0"
     eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/b3f1412f550e35c0d7ae0410db616951116b365167539f9b85710d8bc2b36b322c5e637caee84cc1ae5df8f1d961880250d52ffdef352b31e5bdbef74ba6fea9
+  checksum: 10c0/fd83d2feadaf79950427fbbc3d23ca01cf4646ce7e0dd515a9c881d31ec1cc768e7b8898d3af065e31df39452501a3345092581cbfccac89e89d293519540557
   languageName: node
   linkType: hard
 
@@ -639,9 +639,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001695
-  resolution: "caniuse-lite@npm:1.0.30001695"
-  checksum: 10c0/acf90a767051fdd8083711b3ff9f07a28149c55e394115d8f874f149aa4f130e6bc50cea1dd94fe03035b9ebbe13b64f446518a6d2e19f72650962bdff44b2c5
+  version: 1.0.30001696
+  resolution: "caniuse-lite@npm:1.0.30001696"
+  checksum: 10c0/8060584c612b2bc232995a6e31153432de7946b5417d3b3505a3ab76e632e5568ccc7bae38f1a977f21d4fc214f9e64be829213f810694172c9109e258cb5be8
   languageName: node
   linkType: hard
 
@@ -741,9 +741,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.87
-  resolution: "electron-to-chromium@npm:1.5.87"
-  checksum: 10c0/e1b06a19df9f281477bee8afeb74494ba8f136f867f522d0907c703935f12b59b17581748933a6b86df4886a4ab7a5da88ab3ee029bbfc97dbc75dcf83ad4d5a
+  version: 1.5.90
+  resolution: "electron-to-chromium@npm:1.5.90"
+  checksum: 10c0/864715adfebb5932a78f776c99f28a50942884302b42ee6de0ab64ca135891a5a43af3a7c719a7335687c0ee201561011e37d4994558a795f67b9e44f20fc6ee
   languageName: node
   linkType: hard
 
@@ -862,9 +862,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.6.2":
-  version: 50.6.2
-  resolution: "eslint-plugin-jsdoc@npm:50.6.2"
+"eslint-plugin-jsdoc@npm:^50.6.3":
+  version: 50.6.3
+  resolution: "eslint-plugin-jsdoc@npm:50.6.3"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.49.0"
     are-docs-informative: "npm:^0.0.2"
@@ -879,24 +879,24 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/7349681c33c1a37e8e635b8b354e1ac3f13b348cbdaf8e9b2db878601976d29cb9b2359156e4176ed66b65d10fb237fc6eb2a921512b9fedd811ed6d1a95b445
+  checksum: 10c0/7e0c46675b7cd2133b83969254597bbd3a15694ee2e646a4b7bc8d10babaebe52444d372195649869bcd4d82bcc1fb6b9e21f9a1d187dabd0ac3295d2d3faaff
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.24.1":
-  version: 1.24.1
-  resolution: "eslint-plugin-react-debug@npm:1.24.1"
+"eslint-plugin-react-debug@npm:1.26.0":
+  version: 1.26.0
+  resolution: "eslint-plugin-react-debug@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/core": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/jsx": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@eslint-react/var": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/type-utils": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/core": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/jsx": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@eslint-react/var": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/type-utils": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -907,23 +907,23 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/438897d965cc3da88792d8028380daf5b90f0fd539a15c54d02ae4456139857bbb8aa291834daf1f02d8f9e65a97704aecb73c701fe1f60efb16ceb1bfd274f5
+  checksum: 10c0/23074dc5db484b77500abfa619fb1a4cb06b9fc4ae275dd73895fe4d6e04fe57d587ddf82b88303d32c0858298f634f165f565b52182515c1161a4748bcf7bbb
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.24.1":
-  version: 1.24.1
-  resolution: "eslint-plugin-react-dom@npm:1.24.1"
+"eslint-plugin-react-dom@npm:1.26.0":
+  version: 1.26.0
+  resolution: "eslint-plugin-react-dom@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/core": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/jsx": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@eslint-react/var": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/core": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/jsx": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@eslint-react/var": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.6.2"
@@ -935,24 +935,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/2199dc9ea966822aa8fd072b8734d083caf65b1dd0aa5133a998c46283691ce570da26d4d4dd2efd949440d196926374474f57eafd230813787c57cf150367f4
+  checksum: 10c0/8bb292678b94d6f95ed68eedb156a99501f14e974b2430b009c1c39545c9ee2ebfa3dca09157cbdfbdeea73000b1e0a2a682553029ee81f991dc482ee2a41d3f
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.24.1":
-  version: 1.24.1
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.24.1"
+"eslint-plugin-react-hooks-extra@npm:1.26.0":
+  version: 1.26.0
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/core": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/jsx": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@eslint-react/var": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/type-utils": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/core": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/jsx": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@eslint-react/var": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/type-utils": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -963,7 +963,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/354dda5d4fb943f43d1da7ad80bc9ac7faf937504ee4313e3997d89b990751dc8199f9eb2e951dbf3c1234cb32fdcec4b514a666df35c0545dc687047fd6e5f6
+  checksum: 10c0/d0ef8afa687367c3c4f517e9976b617965759086f3b3a28d33dc869aa4761c33e83d5deb8a97c74c1a89b8c5d1549a0f88bf192ba1956f491822ba723a99e940
   languageName: node
   linkType: hard
 
@@ -976,19 +976,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.24.1":
-  version: 1.24.1
-  resolution: "eslint-plugin-react-naming-convention@npm:1.24.1"
+"eslint-plugin-react-naming-convention@npm:1.26.0":
+  version: 1.26.0
+  resolution: "eslint-plugin-react-naming-convention@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/core": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/jsx": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/type-utils": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/core": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/jsx": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/type-utils": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -999,7 +999,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/52c1f58a49cadf5b1203c5a6ff8c41434201e56e4f6d6735fd387e10730c3998a23d19e479d2aaf928be072618c9724c4f05863d081e502cfbae13363a0f3d5a
+  checksum: 10c0/b3e24a40a17e91019679038c905eb0eca140304d173b902444cb76c4688ca7bb2eea20281a5f05bd848f9d4d7a1a4cf436f617a6aa0676c5c4d5d3f09944718f
   languageName: node
   linkType: hard
 
@@ -1012,19 +1012,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.24.1":
-  version: 1.24.1
-  resolution: "eslint-plugin-react-web-api@npm:1.24.1"
+"eslint-plugin-react-web-api@npm:1.26.0":
+  version: 1.26.0
+  resolution: "eslint-plugin-react-web-api@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/core": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/jsx": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@eslint-react/var": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/core": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/jsx": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@eslint-react/var": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     string-ts: "npm:^2.2.0"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -1035,24 +1035,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/ea0945af74a3243001577df9cad8bb030d72a498f0a7929947b46ecac94f9ea3e7c59b8203f8e6344169db7ddae70ee9158256497ccba67e7677204692c4a109
+  checksum: 10c0/1112fc266af75690bb37420d720c7643f222ef7247d5f39898c3f658893e90d637d1615bc7a0abbfddb3ddda012575b813c416fbd2bc5b8105e28ba30e337877
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.24.1":
-  version: 1.24.1
-  resolution: "eslint-plugin-react-x@npm:1.24.1"
+"eslint-plugin-react-x@npm:1.26.0":
+  version: 1.26.0
+  resolution: "eslint-plugin-react-x@npm:1.26.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.24.1"
-    "@eslint-react/core": "npm:1.24.1"
-    "@eslint-react/eff": "npm:1.24.1"
-    "@eslint-react/jsx": "npm:1.24.1"
-    "@eslint-react/shared": "npm:1.24.1"
-    "@eslint-react/var": "npm:1.24.1"
-    "@typescript-eslint/scope-manager": "npm:^8.21.0"
-    "@typescript-eslint/type-utils": "npm:^8.21.0"
-    "@typescript-eslint/types": "npm:^8.21.0"
-    "@typescript-eslint/utils": "npm:^8.21.0"
+    "@eslint-react/ast": "npm:1.26.0"
+    "@eslint-react/core": "npm:1.26.0"
+    "@eslint-react/eff": "npm:1.26.0"
+    "@eslint-react/jsx": "npm:1.26.0"
+    "@eslint-react/shared": "npm:1.26.0"
+    "@eslint-react/var": "npm:1.26.0"
+    "@typescript-eslint/scope-manager": "npm:^8.22.0"
+    "@typescript-eslint/type-utils": "npm:^8.22.0"
+    "@typescript-eslint/types": "npm:^8.22.0"
+    "@typescript-eslint/utils": "npm:^8.22.0"
     compare-versions: "npm:^6.1.1"
     is-immutable-type: "npm:^5.0.1"
     string-ts: "npm:^2.2.0"
@@ -1068,7 +1068,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/25f3f6c93b3f93a7881f1df2b95f38c2962aa3fccc4c60b565ff77d1cc2bdb6b719ac10c262a1ef8d14a1935dabdf9d9107e82e8f6acbcb49ff7300ba8f36f52
+  checksum: 10c0/134e81a1f010bba57933a07dd816bd6bf4e6e54206176b0ca1ee5e2adcf781cf873bcb28265c3157da6fcd0c8362a8138befdea84f98eb67ce04d73cd02f16c4
   languageName: node
   linkType: hard
 
@@ -1117,16 +1117,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.18.0":
-  version: 9.18.0
-  resolution: "eslint@npm:9.18.0"
+"eslint@npm:^9.19.0":
+  version: 9.19.0
+  resolution: "eslint@npm:9.19.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.0"
     "@eslint/core": "npm:^0.10.0"
     "@eslint/eslintrc": "npm:^3.2.0"
-    "@eslint/js": "npm:9.18.0"
+    "@eslint/js": "npm:9.19.0"
     "@eslint/plugin-kit": "npm:^0.2.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -1162,7 +1162,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/7f592ad228b9bd627a24870fdc875bacdab7bf535d4b67316c4cb791e90d0125130a74769f3c407b0c4b7027b3082ef33864a63ee1024552a60a17db60493f15
+  checksum: 10c0/3b0dfaeff6a831de086884a3e2432f18468fe37c69f35e1a0a9a2833d9994a65b6dd2a524aaee28f361c849035ad9d15e3841029b67d261d0abd62c7de6d51f5
   languageName: node
   linkType: hard
 
@@ -1244,11 +1244,11 @@ __metadata:
   linkType: hard
 
 "fastq@npm:^1.6.0":
-  version: 1.18.0
-  resolution: "fastq@npm:1.18.0"
+  version: 1.19.0
+  resolution: "fastq@npm:1.19.0"
   dependencies:
     reusify: "npm:^1.0.4"
-  checksum: 10c0/7be87ecc41762adbddf558d24182f50a4b1a3ef3ee807d33b7623da7aee5faecdcc94fce5aa13fe91df93e269f383232bbcdb2dc5338cd1826503d6063221f36
+  checksum: 10c0/d6a001638f1574a696660fcbba5300d017760432372c801632c325ca7c16819604841c92fd3ccadcdacec0966ca336363a5ff57bc5f0be335d8ea7ac6087b98f
   languageName: node
   linkType: hard
 
@@ -1807,7 +1807,7 @@ __metadata:
   dependencies:
     "@pandell/eslint-config": "workspace:packages/eslint-config"
     browserslist: "npm:^4.24.4"
-    eslint: "npm:^9.18.0"
+    eslint: "npm:^9.19.0"
     eslint-formatter-teamcity: "npm:^1.0.0"
     prettier: "npm:^3.4.2"
     typescript: "npm:^5.7.3"
@@ -1824,11 +1824,11 @@ __metadata:
   linkType: hard
 
 "semver@npm:^7.6.0, semver@npm:^7.6.3":
-  version: 7.6.3
-  resolution: "semver@npm:7.6.3"
+  version: 7.7.0
+  resolution: "semver@npm:7.7.0"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
+  checksum: 10c0/bcd1c03209b4be7d8ca86c976a0410beba7d4ec1d49d846a4be154b958db1ff5eaee50760c1d4f4070b19dee3236b8672d3e09642c53ea23740398bba2538a2d
   languageName: node
   linkType: hard
 
@@ -1985,17 +1985,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.21.0":
-  version: 8.21.0
-  resolution: "typescript-eslint@npm:8.21.0"
+"typescript-eslint@npm:^8.22.0":
+  version: 8.22.0
+  resolution: "typescript-eslint@npm:8.22.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.21.0"
-    "@typescript-eslint/parser": "npm:8.21.0"
-    "@typescript-eslint/utils": "npm:8.21.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.22.0"
+    "@typescript-eslint/parser": "npm:8.22.0"
+    "@typescript-eslint/utils": "npm:8.22.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/44e5c341ad7f0b41dce3b4ca7a4c0a399ebe51a5323d930750db1e308367b4813a620f4c2332a5774a1dccd0047ebbaf993a8b7effd67389e9069b29b5701520
+  checksum: 10c0/d7a5ec4a08d0eb0a7cc0bf81919f0305a9fbb091b187cef6d3fa220c1673414dcb46e6cd5c9325050d3df2bbb283756399c1b2720eb4eadaab0bdc3cc8302405
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `@eslint-react/eslint-plugin`
    - [1.25.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.25.0)
    - [1.16.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.26.0)
- `@tanstack/eslint-plugin-query`
    - [5.65.0](https://github.com/TanStack/query/releases/tag/v5.65.0)
    - [5.66.0](https://github.com/TanStack/query/releases/tag/v5.66.0)
- `eslint`
    - [9.19.0](https://github.com/eslint/eslint/releases/tag/v9.19.0)
- `eslint-plugin-jsdoc`
    - [50.6.3](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.3)
- `typescript-eslint`
    - [8.22.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.22.0)

---

This PR also enables [`@typescript-eslint/consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/) and [`@typescript-eslint/consistent-type-exports`](https://typescript-eslint.io/rules/consistent-type-exports/) rules as warnings (based on [web-pli PR discussion](https://github.com/pandell/web-pli/pull/1630#discussion_r1936375445)).

Additionally, this PR configures `eslint-formatter-teamcity` to [Inspections mode](https://github.com/andreogle/eslint-formatter-teamcity?tab=readme-ov-file#configuration).
