### PR TITLE
Stylelint upgrade + add "color-named" rule

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -9,6 +9,7 @@ module.exports = {
     "alpha-value-notation": null,
     "at-rule-no-unknown": [true, { "ignoreAtRules": ["mixin", "define-mixin"] }],
     "color-function-notation": null,
+    "color-named": "always-where-possible",
     "custom-property-pattern": null,
     "custom-property-empty-line-before": [
       "always",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pandell/stylelint-config",
-  "version": "15.0.1",
+  "version": "16.0.0",
   "description": "Pandell Shared StyleLint Config",
   "keywords": [
     "pandell",
@@ -18,9 +18,9 @@
   },
   "main": "index.js",
   "peerDependencies": {
-    "stylelint": ">= 15",
-    "stylelint-config-standard": ">= 31",
-    "stylelint-no-unsupported-browser-features": ">= 7",
+    "stylelint": ">= 16",
+    "stylelint-config-standard": ">= 37",
+    "stylelint-no-unsupported-browser-features": ">= 8",
     "stylelint-order": ">= 6"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,9 +339,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/stylelint-config@workspace:packages/stylelint-config"
   peerDependencies:
-    stylelint: ">= 15"
-    stylelint-config-standard: ">= 31"
-    stylelint-no-unsupported-browser-features: ">= 7"
+    stylelint: ">= 16"
+    stylelint-config-standard: ">= 37"
+    stylelint-no-unsupported-browser-features: ">= 8"
     stylelint-order: ">= 6"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR updates `@pandell/stylelint-config` peer dependencies to the latest major version and enables `color-named` rule, as discussed in https://github.com/pandell/web-pli/pull/1634#discussion_r1939974144.