### PR TITLE
@pandell/eslint-config: eslint 9.23 + typescript-eslint 8.28 + NPM updates 2025-03-24

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -18,6 +18,7 @@ packageExtensions:
   "@eslint-react/ast@*": { peerDependencies: { "eslint": ">= 9", "typescript": ">= 5" } }
   "@eslint-react/core@*": { peerDependencies: { "eslint": ">= 9", "typescript": ">= 5" } }
   "@eslint-react/jsx@*": { peerDependencies: { "eslint": ">= 9", "typescript": ">= 5" } }
+  "@eslint-react/kit@*": { peerDependencies: { "eslint": ">= 9", "typescript": ">= 5" } }
   "@eslint-react/shared@*": { peerDependencies: { "eslint": ">= 9", "typescript": ">= 5" } }
   "@eslint-react/var@*": { peerDependencies: { "eslint": ">= 9", "typescript": ">= 5" } }
   "@tanstack/eslint-plugin-query@*": { peerDependencies: { "typescript": ">= 5" } }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@pandell/eslint-config": "workspace:packages/eslint-config",
     "browserslist": "^4.24.4",
-    "eslint": "^9.21.0",
+    "eslint": "^9.22.0",
     "eslint-formatter-teamcity": "^1.0.0",
     "prettier": "^3.5.3",
     "typescript": "~5.8.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@pandell/eslint-config": "workspace:packages/eslint-config",
     "browserslist": "^4.24.4",
-    "eslint": "^9.22.0",
+    "eslint": "^9.23.0",
     "eslint-formatter-teamcity": "^1.0.0",
     "prettier": "^3.5.3",
     "typescript": "~5.8.2"

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -10,7 +10,7 @@ Add the following to your `package.json`:
 {
   "devDependencies": {
     "@pandell/eslint-config": "^9.12.0",
-    "eslint": "^9.21.0",
+    "eslint": "^9.22.0",
     // ...
   },
   // ...

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -10,7 +10,7 @@ Add the following to your `package.json`:
 {
   "devDependencies": {
     "@pandell/eslint-config": "^9.12.0",
-    "eslint": "^9.22.0",
+    "eslint": "^9.23.0",
     // ...
   },
   // ...

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,7 +9,7 @@ Add the following to your `package.json`:
 ```jsonc
 {
   "devDependencies": {
-    "@pandell/eslint-config": "^9.12.0",
+    "@pandell/eslint-config": "^9.13.0",
     "eslint": "^9.23.0",
     // ...
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.37.3",
+    "@eslint-react/eslint-plugin": "^1.38.0",
     "@eslint/js": "^9.23.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.28.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.8.6",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",
-    "eslint-plugin-jsdoc": "^50.6.6",
+    "eslint-plugin-jsdoc": "^50.6.8",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^4.2.2",
-    "eslint-plugin-import-x": "^4.8.1",
+    "eslint-plugin-import-x": "^4.9.0",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.8",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,12 +28,12 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.31.0",
+    "@eslint-react/eslint-plugin": "^1.32.0",
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.67.2",
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.37",
-    "eslint-import-resolver-typescript": "^3.8.3",
+    "eslint-import-resolver-typescript": "^3.8.6",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.6",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.38",
-    "eslint-import-resolver-typescript": "^4.2.1",
+    "eslint-import-resolver-typescript": "^4.2.2",
     "eslint-plugin-import-x": "^4.8.1",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.8",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.32.0",
+    "@eslint-react/eslint-plugin": "^1.32.1",
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.67.2",
     "@typescript-eslint/utils": "^8.26.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^4.2.1",
-    "eslint-plugin-import-x": "^4.8.0",
+    "eslint-plugin-import-x": "^4.8.1",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.8",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@eslint-react/eslint-plugin": "^1.31.0",
     "@eslint/js": "^9.22.0",
-    "@tanstack/eslint-plugin-query": "^5.66.1",
+    "@tanstack/eslint-plugin-query": "^5.67.2",
     "@typescript-eslint/utils": "^8.26.0",
     "@vitest/eslint-plugin": "^1.1.36",
     "eslint-import-resolver-typescript": "^3.8.3",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,7 +31,7 @@
     "@eslint-react/eslint-plugin": "^1.37.3",
     "@eslint/js": "^9.23.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
-    "@typescript-eslint/utils": "^8.27.0",
+    "@typescript-eslint/utils": "^8.28.0",
     "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^4.2.2",
     "eslint-plugin-import-x": "^4.9.1",
@@ -41,7 +41,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-testing-library": "^7.1.1",
-    "typescript-eslint": "^8.27.0"
+    "typescript-eslint": "^8.28.0"
   },
   "devDependencies": {
     "eslint": "^9.23.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.37.0",
+    "@eslint-react/eslint-plugin": "^1.37.3",
     "@eslint/js": "^9.23.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.27.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.30.2",
+    "@eslint-react/eslint-plugin": "^1.31.0",
     "@eslint/js": "^9.21.0",
     "@tanstack/eslint-plugin-query": "^5.66.1",
     "@typescript-eslint/utils": "^8.26.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.30.1",
+    "@eslint-react/eslint-plugin": "^1.30.2",
     "@eslint/js": "^9.21.0",
     "@tanstack/eslint-plugin-query": "^5.66.1",
     "@typescript-eslint/utils": "^8.26.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.36.1",
+    "@eslint-react/eslint-plugin": "^1.37.0",
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.27.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/utils": "^8.27.0",
     "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^4.2.2",
-    "eslint-plugin-import-x": "^4.9.0",
+    "eslint-plugin-import-x": "^4.9.1",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.8",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.32.1",
+    "@eslint-react/eslint-plugin": "^1.35.0",
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.26.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@eslint-react/eslint-plugin": "^1.32.1",
     "@eslint/js": "^9.22.0",
-    "@tanstack/eslint-plugin-query": "^5.67.2",
+    "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^3.8.6",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.38",
-    "eslint-import-resolver-typescript": "^3.8.6",
+    "eslint-import-resolver-typescript": "^4.2.0",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.8",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.8.3",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",
-    "eslint-plugin-jsdoc": "^50.6.3",
+    "eslint-plugin-jsdoc": "^50.6.6",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "prepack": "node ../../tools/clean-package-json.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.35.0",
+    "@eslint-react/eslint-plugin": "^1.36.1",
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.26.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/eslint-config",
   "type": "module",
-  "version": "9.12.0",
+  "version": "9.13.0",
   "description": "Pandell ESLint shared config",
   "keywords": [
     "eslint",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@eslint-react/eslint-plugin": "^1.31.0",
-    "@eslint/js": "^9.21.0",
+    "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.66.1",
     "@typescript-eslint/utils": "^8.26.0",
     "@vitest/eslint-plugin": "^1.1.36",
@@ -44,7 +44,7 @@
     "typescript-eslint": "^8.26.0"
   },
   "devDependencies": {
-    "eslint": "^9.21.0",
+    "eslint": "^9.22.0",
     "typescript": "~5.8.2"
   },
   "peerDependencies": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,7 +32,7 @@
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.67.2",
     "@typescript-eslint/utils": "^8.26.1",
-    "@vitest/eslint-plugin": "^1.1.37",
+    "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^3.8.6",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,7 +32,7 @@
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.67.2",
     "@typescript-eslint/utils": "^8.26.1",
-    "@vitest/eslint-plugin": "^1.1.36",
+    "@vitest/eslint-plugin": "^1.1.37",
     "eslint-import-resolver-typescript": "^3.8.3",
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-jest-dom": "^5.5.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@eslint-react/eslint-plugin": "^1.37.0",
-    "@eslint/js": "^9.22.0",
+    "@eslint/js": "^9.23.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.27.0",
     "@vitest/eslint-plugin": "^1.1.38",
@@ -44,7 +44,7 @@
     "typescript-eslint": "^8.27.0"
   },
   "devDependencies": {
-    "eslint": "^9.22.0",
+    "eslint": "^9.23.0",
     "typescript": "~5.8.2"
   },
   "peerDependencies": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^4.2.2",
     "eslint-plugin-import-x": "^4.9.1",
     "eslint-plugin-jest-dom": "^5.5.0",
-    "eslint-plugin-jsdoc": "^50.6.8",
+    "eslint-plugin-jsdoc": "^50.6.9",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.38",
-    "eslint-import-resolver-typescript": "^4.2.0",
+    "eslint-import-resolver-typescript": "^4.2.1",
     "eslint-plugin-import-x": "^4.8.0",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.8",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,7 +31,7 @@
     "@eslint-react/eslint-plugin": "^1.31.0",
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.67.2",
-    "@typescript-eslint/utils": "^8.26.0",
+    "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.36",
     "eslint-import-resolver-typescript": "^3.8.3",
     "eslint-plugin-import-x": "^4.6.1",
@@ -41,7 +41,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-testing-library": "^7.1.1",
-    "typescript-eslint": "^8.26.0"
+    "typescript-eslint": "^8.26.1"
   },
   "devDependencies": {
     "eslint": "^9.22.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^4.2.0",
-    "eslint-plugin-import-x": "^4.6.1",
+    "eslint-plugin-import-x": "^4.8.0",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsdoc": "^50.6.8",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,7 +31,7 @@
     "@eslint-react/eslint-plugin": "^1.36.1",
     "@eslint/js": "^9.22.0",
     "@tanstack/eslint-plugin-query": "^5.68.0",
-    "@typescript-eslint/utils": "^8.26.1",
+    "@typescript-eslint/utils": "^8.27.0",
     "@vitest/eslint-plugin": "^1.1.38",
     "eslint-import-resolver-typescript": "^4.2.2",
     "eslint-plugin-import-x": "^4.9.0",
@@ -41,7 +41,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-testing-library": "^7.1.1",
-    "typescript-eslint": "^8.26.1"
+    "typescript-eslint": "^8.27.0"
   },
   "devDependencies": {
     "eslint": "^9.22.0",

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -364,7 +364,7 @@ function createPandellViteConfig(
   settings: PandellEsLintConfigSettings,
 ): ReadonlyArray<Linter.Config> {
   const { vite = {} } = settings;
-  const { enabled = false, tsConfigPath = "tsconfig.node.json", files = ["vite.config.ts"] } = vite;
+  const { enabled = false, tsConfigPath = "tsconfig.node.json", files = ["vite.*.ts"] } = vite;
 
   if (!enabled) {
     return [];
@@ -631,7 +631,7 @@ export interface PandellEsLintConfigSettings {
     /**
      * Sets the files that will be analyzed with Vite's "tsConfigPath".
      *
-     * @default ["vite.config.ts"]
+     * @default "vite.*.ts"
      */
     readonly files?: string[];
   };

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -103,13 +103,17 @@ async function createPandellTypeScriptConfig(
     files = defaultTypeScriptFiles,
     noExplicitAny = "error",
     preferNullishCoalescing = "off",
-    parserOptions = { project: true },
+    parserOptions = { projectService: true },
     strict = true,
+    tsconfigRootDir,
     typeChecked = true,
   } = typeScript;
 
   if (!enabled) {
     return [];
+  }
+  if (tsconfigRootDir) {
+    parserOptions.tsconfigRootDir = tsconfigRootDir;
   }
 
   const esLintTs = await import("typescript-eslint");
@@ -585,7 +589,7 @@ export interface PandellEsLintConfigSettings {
      * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#support-for-importmeta,
      * for example "interface ImportMeta { dirname: string; }".
      *
-     * @default {project:true}
+     * @default {projectService:true}
      */
     readonly parserOptions?: TSESLint.ParserOptions;
 
@@ -597,6 +601,15 @@ export interface PandellEsLintConfigSettings {
      * @default true
      */
     readonly strict?: boolean;
+
+    /**
+     * When a truthy string, will set "languageOptions.parserOptions.tsconfigRootDir".
+     *
+     * For more information see https://typescript-eslint.io/blog/typed-linting/#enabling-typed-linting.
+     * Note that documentation page https://typescript-eslint.io/troubleshooting/typed-linting/performance/#project-service-issues
+     * does not include "tsconfigRootDir" property.
+     */
+    readonly tsconfigRootDir?: string | null;
 
     /**
      * Should the TypeScript configuration include type-checked rules?

--- a/packages/eslint-config/src/pandellEsLintConfig.ts
+++ b/packages/eslint-config/src/pandellEsLintConfig.ts
@@ -320,8 +320,7 @@ async function createPandellTestingConfig(
   }
   if (vitest) {
     configs.push({
-      ...(vitest.default.configs.recommended as unknown as Linter.Config),
-      name: "vitest/recommended",
+      ...vitest.default.configs.recommended,
       files: resolvedFiles,
     });
   }

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -31,11 +31,11 @@
     "@types/webpack": "^5.28.5",
     "assets-webpack-plugin": "^7.1.1",
     "css-loader": "^7.1.2",
-    "css-minimizer-webpack-plugin": "^7.0.0",
+    "css-minimizer-webpack-plugin": "^7.0.2",
     "mini-css-extract-plugin": "^2.9.2",
     "open": "^10.1.0",
     "postcss-loader": "^8.1.1",
-    "terser-webpack-plugin": "^5.3.12"
+    "terser-webpack-plugin": "^5.3.14"
   },
   "devDependencies": {
     "postcss": "^8.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,7 +597,7 @@ __metadata:
     "@eslint-react/eslint-plugin": "npm:^1.36.1"
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^4.2.2"
@@ -609,7 +609,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     eslint-plugin-testing-library: "npm:^7.1.1"
     typescript: "npm:~5.8.2"
-    typescript-eslint: "npm:^8.26.1"
+    typescript-eslint: "npm:^8.27.0"
   peerDependencies:
     eslint: ">= 9"
     typescript: ">= 5"
@@ -851,15 +851,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.26.1"
+"@typescript-eslint/eslint-plugin@npm:8.27.0":
+  version: 8.27.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.27.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.26.1"
-    "@typescript-eslint/type-utils": "npm:8.26.1"
-    "@typescript-eslint/utils": "npm:8.26.1"
-    "@typescript-eslint/visitor-keys": "npm:8.26.1"
+    "@typescript-eslint/scope-manager": "npm:8.27.0"
+    "@typescript-eslint/type-utils": "npm:8.27.0"
+    "@typescript-eslint/utils": "npm:8.27.0"
+    "@typescript-eslint/visitor-keys": "npm:8.27.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -868,64 +868,64 @@ __metadata:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/412f41aafd503a1faea91edd03a68717ca8a49ed6683700b8386115c67b86110c9826d10005d3a0341b78cdee41a6ef08842716ced2b58af03f91eb1b8cc929c
+  checksum: 10c0/95bbab011bfe51ca657ff346e4c6cac25652c88e5188a5e74d14372dba45c3d7aa713f4c90f80ebc885d77a8be89e131e8b77c096145c90da6c251a475b125fc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/parser@npm:8.26.1"
+"@typescript-eslint/parser@npm:8.27.0":
+  version: 8.27.0
+  resolution: "@typescript-eslint/parser@npm:8.27.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.26.1"
-    "@typescript-eslint/types": "npm:8.26.1"
-    "@typescript-eslint/typescript-estree": "npm:8.26.1"
-    "@typescript-eslint/visitor-keys": "npm:8.26.1"
+    "@typescript-eslint/scope-manager": "npm:8.27.0"
+    "@typescript-eslint/types": "npm:8.27.0"
+    "@typescript-eslint/typescript-estree": "npm:8.27.0"
+    "@typescript-eslint/visitor-keys": "npm:8.27.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/21fe4306b6017bf183d92cdd493edacd302816071e29e1400452f3ccd224ab8111b75892507b9731545e98e6e4d153e54dab568b3433f6c9596b6cb2f7af922f
+  checksum: 10c0/2ada98167ca5a474544fada7658d7c8d54ea4dfdd692e3d30d18b5531e50d7308a5b09d23dca651f9fe841f96075ccd18643431f4b61d0e4e7e7ccde888258e8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.26.1, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.26.1"
+"@typescript-eslint/scope-manager@npm:8.27.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.1":
+  version: 8.27.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.27.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.26.1"
-    "@typescript-eslint/visitor-keys": "npm:8.26.1"
-  checksum: 10c0/ecd30eb615c7384f01cea8f2c8e8dda7507ada52ad0d002d3701bdd9d06f6d14cefb31c6c26ef55708adfaa2045a01151e8685656240268231a4bac8f792afe4
+    "@typescript-eslint/types": "npm:8.27.0"
+    "@typescript-eslint/visitor-keys": "npm:8.27.0"
+  checksum: 10c0/d87daeffb81f4e70f168c38f01c667713bda71c4545e28fcdf0792378fb3df171894ef77854c5c1a5e5a22c784ee1ccea2dd856b5baf825840710a6a74c14ac9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.26.1, @typescript-eslint/type-utils@npm:^8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/type-utils@npm:8.26.1"
+"@typescript-eslint/type-utils@npm:8.27.0, @typescript-eslint/type-utils@npm:^8.26.1":
+  version: 8.27.0
+  resolution: "@typescript-eslint/type-utils@npm:8.27.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.26.1"
-    "@typescript-eslint/utils": "npm:8.26.1"
+    "@typescript-eslint/typescript-estree": "npm:8.27.0"
+    "@typescript-eslint/utils": "npm:8.27.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/17553b4333246e1ffd447dab78a4cbc565c129c9baf32326387760c9790120a99d955acf84888b7ef96e73c82fc22a3e08e80f0bd65d21e3cf2fe002f977aba1
+  checksum: 10c0/f38cdc660ebcb3b71496182b9ea52301ab08a4f062558aa7061a5f0b759ae3e8f68ae250a29e74251cb52c6c56733d7dabed7002b993544cbe0933bb75d67a57
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.26.1, @typescript-eslint/types@npm:^8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/types@npm:8.26.1"
-  checksum: 10c0/805b239b57854fc12eae9e2bec6ccab24bac1d30a762c455f22c73b777a5859c64c58b4750458bd0ab4aadd664eb95cbef091348a071975acac05b15ebea9f1b
+"@typescript-eslint/types@npm:8.27.0, @typescript-eslint/types@npm:^8.26.1":
+  version: 8.27.0
+  resolution: "@typescript-eslint/types@npm:8.27.0"
+  checksum: 10c0/9c5f2ba816a9baea5982feeadebe4d19f4df77ddb025a7b2307f9e1e6914076b63cbad81f7f915814e64b4d915052cf27bd79ce3e5a831340cb5ab244133941b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.26.1, @typescript-eslint/typescript-estree@npm:^8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.26.1"
+"@typescript-eslint/typescript-estree@npm:8.27.0, @typescript-eslint/typescript-estree@npm:^8.26.1":
+  version: 8.27.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.27.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.26.1"
-    "@typescript-eslint/visitor-keys": "npm:8.26.1"
+    "@typescript-eslint/types": "npm:8.27.0"
+    "@typescript-eslint/visitor-keys": "npm:8.27.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -934,32 +934,32 @@ __metadata:
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/adc95e4735a8ded05ad35d7b4fae68c675afdd4b3531bc4a51eab5efe793cf80bc75f56dfc8022af4c0a5b316eec61f8ce6b77c2ead45fc675fea7e28cd52ade
+  checksum: 10c0/c04d602825ff2a7b2a89746a68b32f7052fb4ce3d2355d1f4e6f43fd064f17c3b44fb974c98838a078fdebdc35152d2ab0af34663dfca99db7a790bd3fc5d8ac
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.26.1, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/utils@npm:8.26.1"
+"@typescript-eslint/utils@npm:8.27.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.1, @typescript-eslint/utils@npm:^8.27.0":
+  version: 8.27.0
+  resolution: "@typescript-eslint/utils@npm:8.27.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.26.1"
-    "@typescript-eslint/types": "npm:8.26.1"
-    "@typescript-eslint/typescript-estree": "npm:8.26.1"
+    "@typescript-eslint/scope-manager": "npm:8.27.0"
+    "@typescript-eslint/types": "npm:8.27.0"
+    "@typescript-eslint/typescript-estree": "npm:8.27.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/a5cb3bdf253cc8e8474a2ed8666c0a6194abe56f44039c6623bef0459ed17d0276ed6e40c70d35bd8ec4d41bafc255e4d3025469f32ac692ba2d89e7579c2a26
+  checksum: 10c0/dcfd5f2c17f1a33061e3ec70d0946ff23a4238aabacae3d85087165beccedf84fb8506d30848f2470e3b60ab98b230aef79c6e8b4c5d39648a37ac559ac5b1e0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.26.1":
-  version: 8.26.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.26.1"
+"@typescript-eslint/visitor-keys@npm:8.27.0":
+  version: 8.27.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.27.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/types": "npm:8.27.0"
     eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/51b1016d06cd2b9eac0a213de418b0a26022fd3b71478014541bfcbc2a3c4d666552390eb9c209fa9e52c868710d9f1b21a2c789d35c650239438c366a27a239
+  checksum: 10c0/d86fd4032db07123816aab3a6b8b53f840387385ab2a4d8f96b22fc76b5438fb27ac8dc42b63caf23f3d265c33e9075dbf1ce8d31f939df12f5cd077d3b10295
   languageName: node
   linkType: hard
 
@@ -4445,17 +4445,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.26.1":
-  version: 8.26.1
-  resolution: "typescript-eslint@npm:8.26.1"
+"typescript-eslint@npm:^8.27.0":
+  version: 8.27.0
+  resolution: "typescript-eslint@npm:8.27.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.26.1"
-    "@typescript-eslint/parser": "npm:8.26.1"
-    "@typescript-eslint/utils": "npm:8.26.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.27.0"
+    "@typescript-eslint/parser": "npm:8.27.0"
+    "@typescript-eslint/utils": "npm:8.27.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/92ab2e59950020eae9956e0e1fd572bc98bab0f764e63f49bfd9feab3b38edfe888712fd2df6fc43642b9be06e60288f72626d7a7cc25dcbb4c692df64cba064
+  checksum: 10c0/f66f8311418b12bca751e8e1c68e42c638745765be40621b65f287a15dd58d4a71e3a0f80756d5c3cc9070a93bb1745887fce2260117e19e1b70f2804cefd351
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,62 +227,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.32.0":
-  version: 1.32.0
-  resolution: "@eslint-react/ast@npm:1.32.0"
+"@eslint-react/ast@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@eslint-react/ast@npm:1.32.1"
   dependencies:
-    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/typescript-estree": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/7d31f0ea73762fcdba4218243713b72d3a06c084287d9f10f25967f99184d90820e09838bbcfd25880c26d08aec8a07a798c055c148673c01220acf4b23b6a0f
+  checksum: 10c0/4beb4df6380f91c5341379856e870e0778174c23ade9255c5d6bc2573cc3a77ef9021802aa4e9b63eecde222911e93008ac9ba40b68196ae71e11176123c4d4e
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.32.0":
-  version: 1.32.0
-  resolution: "@eslint-react/core@npm:1.32.0"
+"@eslint-react/core@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@eslint-react/core@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/jsx": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/jsx": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/f0b1e04da56ea24e0dbee64f3816d532f880e86b5891be9b69ac82d2c3bcdba4919e1d55f7eec58957bba2277bdac72a6d38c05e7df2ad201adddeed692e796f
+  checksum: 10c0/3dc65c773f4414556a15d05d013d1ac9e3fcab2723035440a2354b664169617f495d1ec8775158aadaa9df8800b6173fed75351339881c25dee523f8d4830463
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.32.0":
-  version: 1.32.0
-  resolution: "@eslint-react/eff@npm:1.32.0"
-  checksum: 10c0/3950b71e7073c5ecae5ab7bc6951872eea316fc8d10d8e67b9f11d4c5ac36ae0be7788a7ff18cc58a6e92690b8f6e932c2c09d535061dc3ee47ba4841e9fb13e
+"@eslint-react/eff@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@eslint-react/eff@npm:1.32.1"
+  checksum: 10c0/a9dd84010e6a62a5695e22f67ed03c0ede3b3e35be811ebecd97630b5dd8206606fb8b6307b1c9f165e6c36a3665b0172ea633d4d27af8eab4e9abbf4a48f96e
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.32.0":
-  version: 1.32.0
-  resolution: "@eslint-react/eslint-plugin@npm:1.32.0"
+"@eslint-react/eslint-plugin@npm:^1.32.1":
+  version: 1.32.1
+  resolution: "@eslint-react/eslint-plugin@npm:1.32.1"
   dependencies:
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
-    eslint-plugin-react-debug: "npm:1.32.0"
-    eslint-plugin-react-dom: "npm:1.32.0"
-    eslint-plugin-react-hooks-extra: "npm:1.32.0"
-    eslint-plugin-react-naming-convention: "npm:1.32.0"
-    eslint-plugin-react-web-api: "npm:1.32.0"
-    eslint-plugin-react-x: "npm:1.32.0"
+    eslint-plugin-react-debug: "npm:1.32.1"
+    eslint-plugin-react-dom: "npm:1.32.1"
+    eslint-plugin-react-hooks-extra: "npm:1.32.1"
+    eslint-plugin-react-naming-convention: "npm:1.32.1"
+    eslint-plugin-react-web-api: "npm:1.32.1"
+    eslint-plugin-react-x: "npm:1.32.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -291,49 +291,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/bde0e643e32d393ebfd0f1bba0f2f94f2278ef0e6e35d9d40d198f9c77bca7df7d4df223f9365c54e89fd43c554a71237b4bb5d8cdd0413bb8c5795f12b3696a
+  checksum: 10c0/c22568cb8b55b8e4f05e0db43197773496006959983d2d44b8cd9fc3e5b11a9b37be1f16ef9e78fcd4a0e87ea19d43429e9c2b2958d663327a12fdc8d4d71769
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.32.0":
-  version: 1.32.0
-  resolution: "@eslint-react/jsx@npm:1.32.0"
+"@eslint-react/jsx@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@eslint-react/jsx@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/4f99e78d09821692e476f188aa48c5979b4104d9400e292b7c7eaeea68872d615baaca0f2427e2c754385325c42e540bed8a66fc6043322b17f6f9c651389dc1
+  checksum: 10c0/9f1dd15f2a5dede5e86d580cd5ac8519e6ed5707cec1afa6dfe4c875419f5fb325b1e7139ad68347703e082cfb89b6d0b9ace3833a52dff18f22d4925ac4857a
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.32.0":
-  version: 1.32.0
-  resolution: "@eslint-react/shared@npm:1.32.0"
+"@eslint-react/shared@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@eslint-react/shared@npm:1.32.1"
   dependencies:
-    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/bc039f652fdc89a6285b8e96ebd91c2463917efc0e1d18b217b369a295b3df3fa1c687509c37518b68f9cc4d5466a3e86572b20ad77e91f3bfa83a27b6bc9a49
+  checksum: 10c0/745f9459d2adaf9105a5093e4cc60256c9627c1fa72f9e1afa5d2834224d3995d18b7990b46dc55109be030399fab49f7786f030c258a6dab24d0799c710ed0b
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.32.0":
-  version: 1.32.0
-  resolution: "@eslint-react/var@npm:1.32.0"
+"@eslint-react/var@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@eslint-react/var@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/1c405f85f31019f9e99d5ca91c5b0db5d622d1bb47f0e3935b65f22805c2ae486499dd1ec4a33f27a98d66ef6a0d54f04a6c7f13c0e81443134d423af3781f53
+  checksum: 10c0/582b762337ab2f497b75883994bb29d155e3ee2770b2f36771e4cf1e4e7f7ef6a298037d603b4c61b1af78603d9f2eafe6386dd35740c5e6c18e9fbb49a576b9
   languageName: node
   linkType: hard
 
@@ -562,7 +562,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.32.0"
+    "@eslint-react/eslint-plugin": "npm:^1.32.1"
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.67.2"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -1338,9 +1338,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001703
-  resolution: "caniuse-lite@npm:1.0.30001703"
-  checksum: 10c0/ed88e318da28e9e59c4ac3a2e3c42859558b7b713aebf03696a1f916e4ed4b70734dda82be04635e2b62ec355b8639bbed829b7b12ff528d7f9cc31a3a5bea91
+  version: 1.0.30001704
+  resolution: "caniuse-lite@npm:1.0.30001704"
+  checksum: 10c0/4efa0ece51ef58e7ce7e7c8cd7b50372bcb910581a47397be5c086c046c3cd436d123b734351fb20f638c322b339198edf89b5b632ff59bdd171c74ff7f4efcf
   languageName: node
   linkType: hard
 
@@ -1943,16 +1943,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.32.0":
-  version: 1.32.0
-  resolution: "eslint-plugin-react-debug@npm:1.32.0"
+"eslint-plugin-react-debug@npm:1.32.1":
+  version: 1.32.1
+  resolution: "eslint-plugin-react-debug@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/core": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/jsx": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/core": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/jsx": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -1967,20 +1967,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/1774560bb386ef2d1f4607f0583e92690a86cc0d706eab762b3576cc30f66b082e47e5d6734353bf311ead07a2c7d4d783266fa3eb3949a83c7f5e0742cbe20d
+  checksum: 10c0/8694126c581c914ab18615e6c65ac8dbd5a4fa323dcaf45f4f31c08d6bedb463bf6b761281a9dcf1fe5e05acb942a42c5b4b74f50fe086cc68a5559b43b686f8
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.32.0":
-  version: 1.32.0
-  resolution: "eslint-plugin-react-dom@npm:1.32.0"
+"eslint-plugin-react-dom@npm:1.32.1":
+  version: 1.32.1
+  resolution: "eslint-plugin-react-dom@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/core": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/jsx": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/core": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/jsx": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -1995,20 +1995,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/d6cec86e61cc1a47d86da0313224bea5aa64bf1af217110f915540ff5576daf4e513eb54d35020bdf8b5cfcacc4c5fa19dbf80b81d26a022691bc740a72073d2
+  checksum: 10c0/632dece4d59a7793ed21ce0e0a42d8e338dfa64bee6083b4bbfbd201fb9a8d48666dc1bde547d44e37b0a9d9711c0fbaf73130219c4088c1c4296c2e058469dc
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.32.0":
-  version: 1.32.0
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.32.0"
+"eslint-plugin-react-hooks-extra@npm:1.32.1":
+  version: 1.32.1
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/core": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/jsx": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/core": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/jsx": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2023,7 +2023,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/ee2613fa873c8b41147901e5aadff9dee1908b8aff3ef705b4326cf2a0651d3d891683bc13487196ed56a8be77f6c1a14616894b2d9876c4764440cce1a40143
+  checksum: 10c0/2e727a9f51545d3f4328033804985eb7506af72241f7b7a99679fbc725d8950bd2bb0fe96fd69a1ab456a48a860bb6fc7001f4ccbc6e5806c9d353e6bd169b27
   languageName: node
   linkType: hard
 
@@ -2036,16 +2036,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.32.0":
-  version: 1.32.0
-  resolution: "eslint-plugin-react-naming-convention@npm:1.32.0"
+"eslint-plugin-react-naming-convention@npm:1.32.1":
+  version: 1.32.1
+  resolution: "eslint-plugin-react-naming-convention@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/core": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/jsx": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/core": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/jsx": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2060,7 +2060,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/126ed45b73cca6f7c60020238ca8088770f9f9740065592c20513e6b95fc3936826d9444bccd73e146c9e7752fce958535e6382967f60ca2ae09df3a546fa60d
+  checksum: 10c0/82ec77c093ea3424da1f58812db132633a98aafcab021a32345815959307f62a744cbbe58a0825d2c9a9cade8883e853f38d6305db765d8863703f5d55b2c983
   languageName: node
   linkType: hard
 
@@ -2073,16 +2073,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.32.0":
-  version: 1.32.0
-  resolution: "eslint-plugin-react-web-api@npm:1.32.0"
+"eslint-plugin-react-web-api@npm:1.32.1":
+  version: 1.32.1
+  resolution: "eslint-plugin-react-web-api@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/core": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/jsx": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/core": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/jsx": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -2096,20 +2096,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/bf95bad3d254da69599d7ec64849323a90293e7e1ad2efff140ea3b6c83a1ec3e259b7dbdda8e06ff5cb3bd8547de294e4981aa32a2fb838495593bf51d39c76
+  checksum: 10c0/432f0200c0ce9b1df6ee3124d3cf4ecade0e976999ef76ff690af67423e0f5e9b081288273d840417e2614958867fd8cbc9f1a655025aa4f265f9475931b2098
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.32.0":
-  version: 1.32.0
-  resolution: "eslint-plugin-react-x@npm:1.32.0"
+"eslint-plugin-react-x@npm:1.32.1":
+  version: 1.32.1
+  resolution: "eslint-plugin-react-x@npm:1.32.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.0"
-    "@eslint-react/core": "npm:1.32.0"
-    "@eslint-react/eff": "npm:1.32.0"
-    "@eslint-react/jsx": "npm:1.32.0"
-    "@eslint-react/shared": "npm:1.32.0"
-    "@eslint-react/var": "npm:1.32.0"
+    "@eslint-react/ast": "npm:1.32.1"
+    "@eslint-react/core": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/jsx": "npm:1.32.1"
+    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/var": "npm:1.32.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2128,7 +2128,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/822383a7ae6c4a8bc00c5170c3f18b258c891c3e68f0d77a27e5bdd829b2987f6dbc39ef8b69e66bfc4bc4ea319c5045042407ff11bf8a5d6b6291021e87bbff
+  checksum: 10c0/d796da9ec70d549f6d375df0a9fb9594ce6d5d51ef3d5476f573d27e9a2830aa34d2587b1a65ec4e31f4a787d8ece1367dfa9e55bfbfa328c4b5bdab71b6e587
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,62 +255,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.37.0":
-  version: 1.37.0
-  resolution: "@eslint-react/ast@npm:1.37.0"
+"@eslint-react/ast@npm:1.37.3":
+  version: 1.37.3
+  resolution: "@eslint-react/ast@npm:1.37.3"
   dependencies:
-    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.3"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/typescript-estree": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/17f3c1b72240b297251182f959deba9a6e05b13ee7dd1e86bee6229537ffeeb3ae9f1e2fa340fb47dc53afeb11aa2962d554d25a25f9b9caba8b6b531d52893a
+  checksum: 10c0/90d0026e6f70c2f488464f80b0148b5e7e1d1a9c1eb0377ba367aae6bbe7879bf9a2d5794d2cdd2a39a139c63af33380f11062468c058e683fdbfd6e0958fb68
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.37.0":
-  version: 1.37.0
-  resolution: "@eslint-react/core@npm:1.37.0"
+"@eslint-react/core@npm:1.37.3":
+  version: 1.37.3
+  resolution: "@eslint-react/core@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/jsx": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/jsx": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/type-utils": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/0434b92e9cf2c2d2502c0a97e29a66ae6906da861b2fe10e701485bbb20575c7cea0ba72f859ca4c48c359a1aed4744f3d3d99ba3cd43a155ca3efab60852f41
+  checksum: 10c0/6f8899e32ed036dbefac6592c8cd56cb020d5a85d72e1f39f41201e4bc750d9ec20e73f4928d54d0a662e84f21dc3bfc579965b7af8573ebac7e28f336840443
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.37.0":
-  version: 1.37.0
-  resolution: "@eslint-react/eff@npm:1.37.0"
-  checksum: 10c0/85aa7db15f0e47d49e06fd55f006f0d178fcfbd740b34c9d79204bf06d9e8bcd3a7619165a615607d0aba645a45c01d082c11b4f0afd29fe895f97b7d032f0f9
+"@eslint-react/eff@npm:1.37.3":
+  version: 1.37.3
+  resolution: "@eslint-react/eff@npm:1.37.3"
+  checksum: 10c0/315e71fe8e32fa1958721d923b20b790432ddaa0b1cebef542aca9b76d38cb14481c72bde8ffddf8eafe0bdb6019f5bf04e7dfe191c46d837d0b5839b2080a96
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.37.0":
-  version: 1.37.0
-  resolution: "@eslint-react/eslint-plugin@npm:1.37.0"
+"@eslint-react/eslint-plugin@npm:^1.37.3":
+  version: 1.37.3
+  resolution: "@eslint-react/eslint-plugin@npm:1.37.3"
   dependencies:
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/type-utils": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
-    eslint-plugin-react-debug: "npm:1.37.0"
-    eslint-plugin-react-dom: "npm:1.37.0"
-    eslint-plugin-react-hooks-extra: "npm:1.37.0"
-    eslint-plugin-react-naming-convention: "npm:1.37.0"
-    eslint-plugin-react-web-api: "npm:1.37.0"
-    eslint-plugin-react-x: "npm:1.37.0"
+    eslint-plugin-react-debug: "npm:1.37.3"
+    eslint-plugin-react-dom: "npm:1.37.3"
+    eslint-plugin-react-hooks-extra: "npm:1.37.3"
+    eslint-plugin-react-naming-convention: "npm:1.37.3"
+    eslint-plugin-react-web-api: "npm:1.37.3"
+    eslint-plugin-react-x: "npm:1.37.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -319,49 +319,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/e561e2d9af58cd0c2f34172cef0d6c6a21e2e174fee7becb9e5facb856bbd69da536a66d435f213b4d8f97f4739562d37fb1589a9c3fd1fffbc9a02c0b9074e5
+  checksum: 10c0/e802bb789007d4e9a1179aefe46da37a3dceb2177f0d05a653cec4bd7b39abab74d1212fdf04053f95bc4a717a44ab8011c96dc4c6296633e0456afcc1fe0cca
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.37.0":
-  version: 1.37.0
-  resolution: "@eslint-react/jsx@npm:1.37.0"
+"@eslint-react/jsx@npm:1.37.3":
+  version: 1.37.3
+  resolution: "@eslint-react/jsx@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/76bb1624b6f402cc94081be66ec0d43b2aa0afa1285c53a161800e659ba1366a8d4731f51e5289980498410c1615773a691fe4601086e7a6c61c442dc3e02828
+  checksum: 10c0/4f78eb700ab5bf9610cb6ef5383f6ae7e2830b6e701567d6d803cf72045005250342e245969015a9bc33a9a19ba7578ca0aa43b4a316b501a8bc97f1fb0dfe44
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.37.0":
-  version: 1.37.0
-  resolution: "@eslint-react/shared@npm:1.37.0"
+"@eslint-react/shared@npm:1.37.3":
+  version: 1.37.3
+  resolution: "@eslint-react/shared@npm:1.37.3"
   dependencies:
-    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.3"
     "@typescript-eslint/utils": "npm:^8.27.0"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/f40803f391ca8acd00d33dc1dcfed7d49b91d767a202541beb75b7bd18701456415576345ba07e61ab0f3076d9e32a5e28c0532d11c6d4e80092423cdc118473
+  checksum: 10c0/a8f7776085e38b7d3ff4086aa27cc1edf5b48b30154fc47673fdc380a2ce7dc2927ee9d4b86dd34b75ea542fded676f5d52e42767d440cec1d719b7db8944b20
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.37.0":
-  version: 1.37.0
-  resolution: "@eslint-react/var@npm:1.37.0"
+"@eslint-react/var@npm:1.37.3":
+  version: 1.37.3
+  resolution: "@eslint-react/var@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/d6a810a5e751684c23c848697013340885df70dc0d41c9afe439d26f589c8ca4fb68511b2c4207184d2c9b3ed5bc0b55c6c7321c1ba1d3b3038a591472eda5f0
+  checksum: 10c0/bdc957d10e6db672027f7b0e0bd57dd5fab6a2c0af9114fa562f5cfb7a679ea75abe11523c2943dae82666a4be821cfcfc936cd225be81046838bc2f02fc1244
   languageName: node
   linkType: hard
 
@@ -594,7 +594,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.37.0"
+    "@eslint-react/eslint-plugin": "npm:^1.37.3"
     "@eslint/js": "npm:^9.23.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
@@ -807,11 +807,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 22.13.10
-  resolution: "@types/node@npm:22.13.10"
+  version: 22.13.11
+  resolution: "@types/node@npm:22.13.11"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/a3865f9503d6f718002374f7b87efaadfae62faa499c1a33b12c527cfb9fd86f733e1a1b026b80c5a0e4a965701174bc3305595a7d36078aa1abcf09daa5dee9
+  checksum: 10c0/f6ee33d36372242535c38640fe7550a6640d8a775ec19b55bfc11775b521cba072d892ca92a912332ce01b317293d645c1bf767f3f882ec719f2404a3d2a5b96
   languageName: node
   linkType: hard
 
@@ -898,7 +898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.27.0, @typescript-eslint/type-utils@npm:^8.27.0":
+"@typescript-eslint/type-utils@npm:8.27.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.27.0":
   version: 8.27.0
   resolution: "@typescript-eslint/type-utils@npm:8.27.0"
   dependencies:
@@ -2063,16 +2063,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.37.0":
-  version: 1.37.0
-  resolution: "eslint-plugin-react-debug@npm:1.37.0"
+"eslint-plugin-react-debug@npm:1.37.3":
+  version: 1.37.3
+  resolution: "eslint-plugin-react-debug@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/core": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/jsx": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/core": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/jsx": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/type-utils": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
@@ -2087,20 +2087,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/cbff00b7fcfcabd044a3d7281f4aa83e603fa60f1a2300e3469ab2520c63074d0c1636fde8e0826b3137a46fe98feb708f0c23c3a00b605d3c4560cd89bded6e
+  checksum: 10c0/d40087cd696d84896cf5828615bc959085fad69708be09589522bce84996d3736db69fb6d87dbaf177ce534f19208d206e9d327f8ae497018c076dc6b33351b6
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.37.0":
-  version: 1.37.0
-  resolution: "eslint-plugin-react-dom@npm:1.37.0"
+"eslint-plugin-react-dom@npm:1.37.3":
+  version: 1.37.3
+  resolution: "eslint-plugin-react-dom@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/core": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/jsx": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/core": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/jsx": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
@@ -2115,20 +2115,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/ed848fcdf61e68d5ec7bb4b7e6fff7073a2f40afe584a0c64cb8c2df4bd87f52490461f10ef2596030b7eb678a5b753843bc94632accfc84696f3ba89c6c92dd
+  checksum: 10c0/953bc722908fe64f3364c8a69d82ffd625e69a2c9b88a1910be7f6424f6e802c541bb7daa61293cde7b5a6d796389c443312482541801df102f7db1e4d16f3b7
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.37.0":
-  version: 1.37.0
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.37.0"
+"eslint-plugin-react-hooks-extra@npm:1.37.3":
+  version: 1.37.3
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/core": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/jsx": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/core": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/jsx": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/type-utils": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
@@ -2143,7 +2143,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/fb2b327ab87bdbc52e6da1b18502f4e9cebbb0e0e1ccc8f8aa18564d5987cec9f230e665d7a0388079ea3ae40615e30b7423426e7f6a2c90c897f23a98708a21
+  checksum: 10c0/3139073882b359669105a6eeaf32838594941226b758f68cd01863d57cacf87f92c98be65cfafcbe5cefb14dfb9cf837b277de126216ca7ff33df530809ac334
   languageName: node
   linkType: hard
 
@@ -2156,16 +2156,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.37.0":
-  version: 1.37.0
-  resolution: "eslint-plugin-react-naming-convention@npm:1.37.0"
+"eslint-plugin-react-naming-convention@npm:1.37.3":
+  version: 1.37.3
+  resolution: "eslint-plugin-react-naming-convention@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/core": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/jsx": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/core": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/jsx": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/type-utils": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
@@ -2180,7 +2180,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/bb1c2536926e0cf41a238cb541a65726d16a9d7423861dcb8e67893f9a5dd56cb306b6cc9d1ec3d354f33604eeeacb8f1fe8c095ca16d7de52d01c2b65ac29eb
+  checksum: 10c0/26d3d14ec5e67b0572242aea3986e70a6bb3926c978b716e8b95b466b42f179d127c5b84cb4de89ea566f9477161e88c3a9b42c590fdc7e5941277b169b008cc
   languageName: node
   linkType: hard
 
@@ -2193,16 +2193,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.37.0":
-  version: 1.37.0
-  resolution: "eslint-plugin-react-web-api@npm:1.37.0"
+"eslint-plugin-react-web-api@npm:1.37.3":
+  version: 1.37.3
+  resolution: "eslint-plugin-react-web-api@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/core": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/jsx": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/core": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/jsx": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
@@ -2216,25 +2216,26 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/6bf565dffbb75f04ccb9469c708c753c1e7fc1d99b551a89dd80c0e8a277d35c832d7b612cc95c03acd5bb44ed2fe471ecf10770704dee6da00898b60a4b80d0
+  checksum: 10c0/ef4d8ea6c23292c73254b9a5203625dedc7faa92b3ccccdf989820ee2a89917334215b07cad5f1e0cbc210efb604a4e4773da3586ede46f218ddb24f48320f42
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.37.0":
-  version: 1.37.0
-  resolution: "eslint-plugin-react-x@npm:1.37.0"
+"eslint-plugin-react-x@npm:1.37.3":
+  version: 1.37.3
+  resolution: "eslint-plugin-react-x@npm:1.37.3"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.0"
-    "@eslint-react/core": "npm:1.37.0"
-    "@eslint-react/eff": "npm:1.37.0"
-    "@eslint-react/jsx": "npm:1.37.0"
-    "@eslint-react/shared": "npm:1.37.0"
-    "@eslint-react/var": "npm:1.37.0"
+    "@eslint-react/ast": "npm:1.37.3"
+    "@eslint-react/core": "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.37.3"
+    "@eslint-react/jsx": "npm:1.37.3"
+    "@eslint-react/shared": "npm:1.37.3"
+    "@eslint-react/var": "npm:1.37.3"
     "@typescript-eslint/scope-manager": "npm:^8.27.0"
     "@typescript-eslint/type-utils": "npm:^8.27.0"
     "@typescript-eslint/types": "npm:^8.27.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
     compare-versions: "npm:^6.1.1"
+    is-immutable-type: "npm:^5.0.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2248,7 +2249,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/70f12a37b0e2ecc02c923759ca9db1c912966427fe41a30315eac1dcaf7c5ef9a05ea0ad7193dc2f7a4021ba21ee34b1fc2b0e84e6f66fc781201ebda9a39f99
+  checksum: 10c0/7228cd802dd37263316edd228118442ae2ed414759ced95a50539c53d1da7f7ce3ee78239844312646b39a186e6502644f6e4fe99136fc703b9a9f70b300ace1
   languageName: node
   linkType: hard
 
@@ -2688,6 +2689,20 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"is-immutable-type@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "is-immutable-type@npm:5.0.1"
+  dependencies:
+    "@typescript-eslint/type-utils": "npm:^8.0.0"
+    ts-api-utils: "npm:^2.0.0"
+    ts-declaration-location: "npm:^1.0.4"
+  peerDependencies:
+    eslint: "*"
+    typescript: ">=4.7.4"
+  checksum: 10c0/a46dec39942844f14d9938dd3ff7a9b345ecbb7d9a308a3719b303a088859e5efcfd765730d3bbfcc80fd32bd267d53fa49abaa2313bc792cdaa95ccce0e54c4
   languageName: node
   linkType: hard
 
@@ -4423,12 +4438,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^2.0.1":
+"ts-api-utils@npm:^2.0.0, ts-api-utils@npm:^2.0.1":
   version: 2.1.0
   resolution: "ts-api-utils@npm:2.1.0"
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/9806a38adea2db0f6aa217ccc6bc9c391ddba338a9fe3080676d0d50ed806d305bb90e8cef0276e793d28c8a929f400abb184ddd7ff83a416959c0f4d2ce754f
+  languageName: node
+  linkType: hard
+
+"ts-declaration-location@npm:^1.0.4":
+  version: 1.0.7
+  resolution: "ts-declaration-location@npm:1.0.7"
+  dependencies:
+    picomatch: "npm:^4.0.2"
+  peerDependencies:
+    typescript: ">=4.0.0"
+  checksum: 10c0/b579b7630907052cc174b051dffdb169424824d887d8fb5abdc61e7ab0eede348c2b71c998727b9e4b314c0436f5003a15bb7eedb1c851afe96e12499f159630
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,7 +601,7 @@ __metadata:
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^4.2.1"
-    eslint-plugin-import-x: "npm:^4.8.0"
+    eslint-plugin-import-x: "npm:^4.8.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.8"
     eslint-plugin-react-hooks: "npm:^5.2.0"
@@ -1458,9 +1458,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001705
-  resolution: "caniuse-lite@npm:1.0.30001705"
-  checksum: 10c0/f135a9075e36cc28a66a8f37145dca2bdc45ea18fd9fae2569e781e0f7156962d4fcac374640aa6421a70c6e8d23587bf9386f5561a1fe81bbbf36055b807243
+  version: 1.0.30001706
+  resolution: "caniuse-lite@npm:1.0.30001706"
+  checksum: 10c0/b502d0a509611fd5b009e1123d482e983696984b6b749c3f485fd8d02cc58376c59cf0bb15f22fa2d337da104970edd27dd525d4663cebc728e26ac4adedff0d
   languageName: node
   linkType: hard
 
@@ -2004,9 +2004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import-x@npm:^4.8.0":
-  version: 4.8.0
-  resolution: "eslint-plugin-import-x@npm:4.8.0"
+"eslint-plugin-import-x@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "eslint-plugin-import-x@npm:4.8.1"
   dependencies:
     "@types/doctrine": "npm:^0.0.9"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -2015,13 +2015,13 @@ __metadata:
     eslint-import-resolver-node: "npm:^0.3.9"
     get-tsconfig: "npm:^4.10.0"
     picomatch: "npm:^4.0.2"
-    rspack-resolver: "npm:^1.1.0"
+    rspack-resolver: "npm:^1.2.1"
     semver: "npm:^7.7.1"
     stable-hash: "npm:^0.0.5"
     tslib: "npm:^2.8.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/3c80239e6af0b47f463931cf9cad11bfdbe07d2aa97edf3366049356207cbe6cd53f365649d15ef8e7e0a9e57c063048c9307cf30cb4966d19bf66eb8b2b78f8
+  checksum: 10c0/53de7c1ac0ade79473f46506b9175e652d552c52df2a36df255518853ad44b8786f568613f3a7b60549a67dcf497543b38a813d7be70c7518ba00e5f28d9ebc6
   languageName: node
   linkType: hard
 
@@ -4091,7 +4091,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"rspack-resolver@npm:^1.1.0, rspack-resolver@npm:^1.2.0":
+"rspack-resolver@npm:^1.2.0, rspack-resolver@npm:^1.2.1":
   version: 1.2.1
   resolution: "rspack-resolver@npm:1.2.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,62 +255,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@eslint-react/ast@npm:1.37.3"
+"@eslint-react/ast@npm:1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/ast@npm:1.38.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.37.3"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/typescript-estree": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/typescript-estree": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/90d0026e6f70c2f488464f80b0148b5e7e1d1a9c1eb0377ba367aae6bbe7879bf9a2d5794d2cdd2a39a139c63af33380f11062468c058e683fdbfd6e0958fb68
+  checksum: 10c0/cd3686f81738b983867b5259792e8690525aae61b442404e3c3fa3ee7fb998be7b957367fae2712825af0bebb5b3b63db23aafc2ce567941478e1035a0b3ad15
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@eslint-react/core@npm:1.37.3"
+"@eslint-react/core@npm:1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/core@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/jsx": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/type-utils": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/jsx": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/type-utils": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/6f8899e32ed036dbefac6592c8cd56cb020d5a85d72e1f39f41201e4bc750d9ec20e73f4928d54d0a662e84f21dc3bfc579965b7af8573ebac7e28f336840443
+  checksum: 10c0/d4f9eff2d84761e91f267807c351db1904cacae48888266b8e31b115cbe888b5c39707694fcc285d70be44c2cad2609e30309c7f0107573748d346b0ed7b5589
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@eslint-react/eff@npm:1.37.3"
-  checksum: 10c0/315e71fe8e32fa1958721d923b20b790432ddaa0b1cebef542aca9b76d38cb14481c72bde8ffddf8eafe0bdb6019f5bf04e7dfe191c46d837d0b5839b2080a96
+"@eslint-react/eff@npm:1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/eff@npm:1.38.0"
+  checksum: 10c0/6796135bef73dd323df79f7ebe9a523a931051ef4b49fb1c4d3c09ec5dac2ab6a4673428a12b253bbe2412e7236b724e820364fb0923875aa965f8e837a42656
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.37.3":
-  version: 1.37.3
-  resolution: "@eslint-react/eslint-plugin@npm:1.37.3"
+"@eslint-react/eslint-plugin@npm:^1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/eslint-plugin@npm:1.38.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/type-utils": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
-    eslint-plugin-react-debug: "npm:1.37.3"
-    eslint-plugin-react-dom: "npm:1.37.3"
-    eslint-plugin-react-hooks-extra: "npm:1.37.3"
-    eslint-plugin-react-naming-convention: "npm:1.37.3"
-    eslint-plugin-react-web-api: "npm:1.37.3"
-    eslint-plugin-react-x: "npm:1.37.3"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/type-utils": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
+    eslint-plugin-react-debug: "npm:1.38.0"
+    eslint-plugin-react-dom: "npm:1.38.0"
+    eslint-plugin-react-hooks-extra: "npm:1.38.0"
+    eslint-plugin-react-naming-convention: "npm:1.38.0"
+    eslint-plugin-react-web-api: "npm:1.38.0"
+    eslint-plugin-react-x: "npm:1.38.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -319,49 +321,61 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/e802bb789007d4e9a1179aefe46da37a3dceb2177f0d05a653cec4bd7b39abab74d1212fdf04053f95bc4a717a44ab8011c96dc4c6296633e0456afcc1fe0cca
+  checksum: 10c0/e906b4db36a9d69e4c5f197f09ca1602b9a89da8cbdbe923af250b596a06287de89d75fed98a497b602cc321b33c7d8f4ac31b51b2a3d75c7397e3d3e25a018d
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@eslint-react/jsx@npm:1.37.3"
+"@eslint-react/jsx@npm:1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/jsx@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/4f78eb700ab5bf9610cb6ef5383f6ae7e2830b6e701567d6d803cf72045005250342e245969015a9bc33a9a19ba7578ca0aa43b4a316b501a8bc97f1fb0dfe44
+  checksum: 10c0/dd30d9feaf23c36139ddf23ad0838f735a4ef67e09bfeb9e8750fd73236447e891ad9f39df94015167fd13a2a20bc6570eecc86483f91129b02a25624b52db4f
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@eslint-react/shared@npm:1.37.3"
+"@eslint-react/kit@npm:1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/kit@npm:1.38.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.37.3"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
+    ts-pattern: "npm:^5.6.2"
+  checksum: 10c0/c0e323fb1b68f660ec95df31d5369a6d5cc6a8c5b905194f489ef0b0f52c9002b974e1238e33a014fa59c018a44bfe6d6261364b5f2065ff70739c77ba1ec6ce
+  languageName: node
+  linkType: hard
+
+"@eslint-react/shared@npm:1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/shared@npm:1.38.0"
+  dependencies:
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/a8f7776085e38b7d3ff4086aa27cc1edf5b48b30154fc47673fdc380a2ce7dc2927ee9d4b86dd34b75ea542fded676f5d52e42767d440cec1d719b7db8944b20
+  checksum: 10c0/0bad5e4ee14873f892c82156356e5d744f81b71efd126518a3b62e5cc6ddbc5d49777e404d977583e2ff588625445ae1eee961294cc8db7e129b64556fc3a128
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@eslint-react/var@npm:1.37.3"
+"@eslint-react/var@npm:1.38.0":
+  version: 1.38.0
+  resolution: "@eslint-react/var@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/bdc957d10e6db672027f7b0e0bd57dd5fab6a2c0af9114fa562f5cfb7a679ea75abe11523c2943dae82666a4be821cfcfc936cd225be81046838bc2f02fc1244
+  checksum: 10c0/6892c7b06b637828b03c2e99fc5e8665cbaea85bf4cd05dbba15a73e43b0ecf62832156530dc8e162ee188900be035cca3011bcbc446805cb174773f18458183
   languageName: node
   linkType: hard
 
@@ -594,7 +608,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.37.3"
+    "@eslint-react/eslint-plugin": "npm:^1.38.0"
     "@eslint/js": "npm:^9.23.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
     "@typescript-eslint/utils": "npm:^8.28.0"
@@ -888,7 +902,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.28.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.27.0":
+"@typescript-eslint/scope-manager@npm:8.28.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.28.0":
   version: 8.28.0
   resolution: "@typescript-eslint/scope-manager@npm:8.28.0"
   dependencies:
@@ -898,7 +912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.28.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.27.0":
+"@typescript-eslint/type-utils@npm:8.28.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.28.0":
   version: 8.28.0
   resolution: "@typescript-eslint/type-utils@npm:8.28.0"
   dependencies:
@@ -913,14 +927,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.28.0, @typescript-eslint/types@npm:^8.27.0":
+"@typescript-eslint/types@npm:8.28.0, @typescript-eslint/types@npm:^8.28.0":
   version: 8.28.0
   resolution: "@typescript-eslint/types@npm:8.28.0"
   checksum: 10c0/1f95895e20dac1cf063dc93c99142fd1871e53be816bcbbee93f22a05e6b2a82ca83c20ce3a551f65555910aa0956443a23268edbb004369d0d5cb282d13c377
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.28.0, @typescript-eslint/typescript-estree@npm:^8.27.0":
+"@typescript-eslint/typescript-estree@npm:8.28.0, @typescript-eslint/typescript-estree@npm:^8.28.0":
   version: 8.28.0
   resolution: "@typescript-eslint/typescript-estree@npm:8.28.0"
   dependencies:
@@ -2063,20 +2077,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.37.3":
-  version: 1.37.3
-  resolution: "eslint-plugin-react-debug@npm:1.37.3"
+"eslint-plugin-react-debug@npm:1.38.0":
+  version: 1.38.0
+  resolution: "eslint-plugin-react-debug@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/core": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/jsx": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/type-utils": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/core": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/jsx": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/type-utils": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2087,23 +2102,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/d40087cd696d84896cf5828615bc959085fad69708be09589522bce84996d3736db69fb6d87dbaf177ce534f19208d206e9d327f8ae497018c076dc6b33351b6
+  checksum: 10c0/021511daee74e2fdfa106e073524c2c47f2e3814baefea18b06b6731420811db508962b1b3a0643f3210f5bd521f2154b7eed815d329fd0906bbaf9cee23c098
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.37.3":
-  version: 1.37.3
-  resolution: "eslint-plugin-react-dom@npm:1.37.3"
+"eslint-plugin-react-dom@npm:1.38.0":
+  version: 1.38.0
+  resolution: "eslint-plugin-react-dom@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/core": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/jsx": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/core": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/jsx": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
@@ -2115,24 +2131,25 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/953bc722908fe64f3364c8a69d82ffd625e69a2c9b88a1910be7f6424f6e802c541bb7daa61293cde7b5a6d796389c443312482541801df102f7db1e4d16f3b7
+  checksum: 10c0/394d5e2c643259310dbd4e048cba3a097ccd7fd487eddd8699cb23380925a3987fd5fec23ee4e0436a6b28572c5766154f7cdcb0eb4deb6a59401d05bb029c94
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.37.3":
-  version: 1.37.3
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.37.3"
+"eslint-plugin-react-hooks-extra@npm:1.38.0":
+  version: 1.38.0
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/core": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/jsx": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/type-utils": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/core": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/jsx": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/type-utils": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2143,7 +2160,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/3139073882b359669105a6eeaf32838594941226b758f68cd01863d57cacf87f92c98be65cfafcbe5cefb14dfb9cf837b277de126216ca7ff33df530809ac334
+  checksum: 10c0/038ef2a379ddb1dbca96661aedb63120770bc99bd18345a680418756982167949c5529c966485c29ad2f599748612ff15ba3b2461ee9e087f2794ddffd11502d
   languageName: node
   linkType: hard
 
@@ -2156,20 +2173,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.37.3":
-  version: 1.37.3
-  resolution: "eslint-plugin-react-naming-convention@npm:1.37.3"
+"eslint-plugin-react-naming-convention@npm:1.38.0":
+  version: 1.38.0
+  resolution: "eslint-plugin-react-naming-convention@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/core": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/jsx": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/type-utils": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/core": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/jsx": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/type-utils": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2180,7 +2198,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/26d3d14ec5e67b0572242aea3986e70a6bb3926c978b716e8b95b466b42f179d127c5b84cb4de89ea566f9477161e88c3a9b42c590fdc7e5941277b169b008cc
+  checksum: 10c0/4d9ca0f94e9ab9a34774268131e21834bb207b73db3ca3c13f6eb6d01475f75023973fd1d303cf38ad7d9736c26676816a02cc9d46a98a61aeae1b4025ab34b9
   languageName: node
   linkType: hard
 
@@ -2193,19 +2211,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.37.3":
-  version: 1.37.3
-  resolution: "eslint-plugin-react-web-api@npm:1.37.3"
+"eslint-plugin-react-web-api@npm:1.38.0":
+  version: 1.38.0
+  resolution: "eslint-plugin-react-web-api@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/core": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/jsx": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/core": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/jsx": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2216,24 +2235,25 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/ef4d8ea6c23292c73254b9a5203625dedc7faa92b3ccccdf989820ee2a89917334215b07cad5f1e0cbc210efb604a4e4773da3586ede46f218ddb24f48320f42
+  checksum: 10c0/747d32d90842bfa7ee7f5327398f647b0ecce8e0e53e5c41c48ff3daf4d6532852ba7cd86f5985be39e15510b27e18dda9a37db36589cc84a2884b2b8fbbf226
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.37.3":
-  version: 1.37.3
-  resolution: "eslint-plugin-react-x@npm:1.37.3"
+"eslint-plugin-react-x@npm:1.38.0":
+  version: 1.38.0
+  resolution: "eslint-plugin-react-x@npm:1.38.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.37.3"
-    "@eslint-react/core": "npm:1.37.3"
-    "@eslint-react/eff": "npm:1.37.3"
-    "@eslint-react/jsx": "npm:1.37.3"
-    "@eslint-react/shared": "npm:1.37.3"
-    "@eslint-react/var": "npm:1.37.3"
-    "@typescript-eslint/scope-manager": "npm:^8.27.0"
-    "@typescript-eslint/type-utils": "npm:^8.27.0"
-    "@typescript-eslint/types": "npm:^8.27.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@eslint-react/ast": "npm:1.38.0"
+    "@eslint-react/core": "npm:1.38.0"
+    "@eslint-react/eff": "npm:1.38.0"
+    "@eslint-react/jsx": "npm:1.38.0"
+    "@eslint-react/kit": "npm:1.38.0"
+    "@eslint-react/shared": "npm:1.38.0"
+    "@eslint-react/var": "npm:1.38.0"
+    "@typescript-eslint/scope-manager": "npm:^8.28.0"
+    "@typescript-eslint/type-utils": "npm:^8.28.0"
+    "@typescript-eslint/types": "npm:^8.28.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     compare-versions: "npm:^6.1.1"
     is-immutable-type: "npm:^5.0.1"
     string-ts: "npm:^2.2.1"
@@ -2249,7 +2269,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/7228cd802dd37263316edd228118442ae2ed414759ced95a50539c53d1da7f7ce3ee78239844312646b39a186e6502644f6e4fe99136fc703b9a9f70b300ace1
+  checksum: 10c0/5d76b78cf30e5f8d2c47422de721143ff357be9bf9b8677c112d67e19a3030aa424faf2b8844303436bc8b5999b395d4a2981d99fd4d244d12ce3afdece00328
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,11 +24,11 @@ __metadata:
   linkType: hard
 
 "@babel/runtime@npm:^7.16.3":
-  version: 7.26.10
-  resolution: "@babel/runtime@npm:7.26.10"
+  version: 7.27.0
+  resolution: "@babel/runtime@npm:7.27.0"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
-  checksum: 10c0/6dc6d88c7908f505c4f7770fb4677dfa61f68f659b943c2be1f2a99cb6680343462867abf2d49822adc435932919b36c77ac60125793e719ea8745f2073d3745
+  checksum: 10c0/35091ea9de48bd7fd26fb177693d64f4d195eb58ab2b142b893b7f3fa0f1d7c677604d36499ae0621a3703f35ba0c6a8f6c572cc8f7dc0317213841e493cf663
   languageName: node
   linkType: hard
 
@@ -603,7 +603,7 @@ __metadata:
     eslint-import-resolver-typescript: "npm:^4.2.2"
     eslint-plugin-import-x: "npm:^4.9.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
-    eslint-plugin-jsdoc: "npm:^50.6.8"
+    eslint-plugin-jsdoc: "npm:^50.6.9"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.19"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
@@ -768,9 +768,9 @@ __metadata:
   linkType: hard
 
 "@types/estree@npm:*, @types/estree@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "@types/estree@npm:1.0.6"
-  checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
+  version: 1.0.7
+  resolution: "@types/estree@npm:1.0.7"
+  checksum: 10c0/be815254316882f7c40847336cd484c3bc1c3e34f710d197160d455dc9d6d050ffbf4c3bc76585dba86f737f020ab20bdb137ebe0e9116b0c86c7c0342221b8c
   languageName: node
   linkType: hard
 
@@ -807,11 +807,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 22.13.11
-  resolution: "@types/node@npm:22.13.11"
+  version: 22.13.13
+  resolution: "@types/node@npm:22.13.13"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/f6ee33d36372242535c38640fe7550a6640d8a775ec19b55bfc11775b521cba072d892ca92a912332ce01b317293d645c1bf767f3f882ec719f2404a3d2a5b96
+  checksum: 10c0/daf792ba5dcff1316abf4b33680f94b792f8d54d6ae495efc8929531e0ba1284a248d29aab117d2259f9280284d986ad5799b193b0516e2b926d713aab835f7d
   languageName: node
   linkType: hard
 
@@ -1458,9 +1458,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001706
-  resolution: "caniuse-lite@npm:1.0.30001706"
-  checksum: 10c0/b502d0a509611fd5b009e1123d482e983696984b6b749c3f485fd8d02cc58376c59cf0bb15f22fa2d337da104970edd27dd525d4663cebc728e26ac4adedff0d
+  version: 1.0.30001707
+  resolution: "caniuse-lite@npm:1.0.30001707"
+  checksum: 10c0/a1beaf84bad4f6617bbc5616d6bc0c9cab73e73f7e9e09b6466af5195b1bc393e0f6f19643d7a1c88bd3f4bfa122d7bea81cf6225ec3ade57d5b1dd3478c1a1b
   languageName: node
   linkType: hard
 
@@ -2042,9 +2042,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.6.8":
-  version: 50.6.8
-  resolution: "eslint-plugin-jsdoc@npm:50.6.8"
+"eslint-plugin-jsdoc@npm:^50.6.9":
+  version: 50.6.9
+  resolution: "eslint-plugin-jsdoc@npm:50.6.9"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.49.0"
     are-docs-informative: "npm:^0.0.2"
@@ -2059,7 +2059,7 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/698006f49a10be422ac889ee6a0e33d60b326b67464c6d5e09bfa7205aca03e9e3a4030add01001f4d8e3ecd1ad2f989a0da70bd401dcbf0ea30e8b157f33c45
+  checksum: 10c0/cad199d262c2e889a3af4e402f6adc624e4273b3d5ca1940e7227b37d87af8090ca3444f7fff57f58dab9a827faed8722fc2f5d4daf31ec085eb00e9f5a338a7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,7 +571,7 @@ __metadata:
     eslint-import-resolver-typescript: "npm:^3.8.3"
     eslint-plugin-import-x: "npm:^4.6.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
-    eslint-plugin-jsdoc: "npm:^50.6.3"
+    eslint-plugin-jsdoc: "npm:^50.6.6"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.19"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
@@ -1922,7 +1922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.6.3":
+"eslint-plugin-jsdoc@npm:^50.6.6":
   version: 50.6.6
   resolution: "eslint-plugin-jsdoc@npm:50.6.6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,7 +565,7 @@ __metadata:
     "@eslint-react/eslint-plugin": "npm:^1.31.0"
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.67.2"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     "@vitest/eslint-plugin": "npm:^1.1.36"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^3.8.3"
@@ -577,7 +577,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     eslint-plugin-testing-library: "npm:^7.1.1"
     typescript: "npm:~5.8.2"
-    typescript-eslint: "npm:^8.26.0"
+    typescript-eslint: "npm:^8.26.1"
   peerDependencies:
     eslint: ">= 9"
     typescript: ">= 5"
@@ -810,15 +810,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.26.0"
+"@typescript-eslint/eslint-plugin@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.26.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.26.0"
-    "@typescript-eslint/type-utils": "npm:8.26.0"
-    "@typescript-eslint/utils": "npm:8.26.0"
-    "@typescript-eslint/visitor-keys": "npm:8.26.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.1"
+    "@typescript-eslint/type-utils": "npm:8.26.1"
+    "@typescript-eslint/utils": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -827,64 +827,64 @@ __metadata:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/b270467672c5cb7fb9085ae063364252af2910a424899f2a9f54cfbe84aba6ce80dbbf5027f1f33f17cc587da9883de212a4b3dc969f22ded30076889b499dd8
+  checksum: 10c0/412f41aafd503a1faea91edd03a68717ca8a49ed6683700b8386115c67b86110c9826d10005d3a0341b78cdee41a6ef08842716ced2b58af03f91eb1b8cc929c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/parser@npm:8.26.0"
+"@typescript-eslint/parser@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/parser@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.26.0"
-    "@typescript-eslint/types": "npm:8.26.0"
-    "@typescript-eslint/typescript-estree": "npm:8.26.0"
-    "@typescript-eslint/visitor-keys": "npm:8.26.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.1"
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/typescript-estree": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/b937a80aeca4e508a67cbf2e42dfd268316336de265aaf836d04e49008a6ff4d754e73ad30075c183d98756677d1f54061c34e618c97d5fb61a04903c65d4851
+  checksum: 10c0/21fe4306b6017bf183d92cdd493edacd302816071e29e1400452f3ccd224ab8111b75892507b9731545e98e6e4d153e54dab568b3433f6c9596b6cb2f7af922f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.26.0, @typescript-eslint/scope-manager@npm:^8.1.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.26.0"
+"@typescript-eslint/scope-manager@npm:8.26.1, @typescript-eslint/scope-manager@npm:^8.1.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.0":
+  version: 8.26.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.26.0"
-    "@typescript-eslint/visitor-keys": "npm:8.26.0"
-  checksum: 10c0/f93b12daf6a4df3050ca3fc6db1f534b5c521861509ee09a45a8a17d97f2fbb20c2d34975f07291481d69998aac9f2975f8facad0d47f533db56ec8f70f533a0
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
+  checksum: 10c0/ecd30eb615c7384f01cea8f2c8e8dda7507ada52ad0d002d3701bdd9d06f6d14cefb31c6c26ef55708adfaa2045a01151e8685656240268231a4bac8f792afe4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.26.0, @typescript-eslint/type-utils@npm:^8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/type-utils@npm:8.26.0"
+"@typescript-eslint/type-utils@npm:8.26.1, @typescript-eslint/type-utils@npm:^8.26.0":
+  version: 8.26.1
+  resolution: "@typescript-eslint/type-utils@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.26.0"
-    "@typescript-eslint/utils": "npm:8.26.0"
+    "@typescript-eslint/typescript-estree": "npm:8.26.1"
+    "@typescript-eslint/utils": "npm:8.26.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/840b7551dcea7304632564612a2460f869c5330c50661cf21ac5992359aba7539f1466ac7dbde6f2d0bd56f6f769c9f3fed8564045c82d4914a88745da846870
+  checksum: 10c0/17553b4333246e1ffd447dab78a4cbc565c129c9baf32326387760c9790120a99d955acf84888b7ef96e73c82fc22a3e08e80f0bd65d21e3cf2fe002f977aba1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.26.0, @typescript-eslint/types@npm:^8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/types@npm:8.26.0"
-  checksum: 10c0/b16c0f67d12092c204a5935b430854b3a41c80934b386a5a4526acc9c8a829d8ee4f78732e71587e605de7845fa9a801b59fff015471dab7bf33676ee68c0100
+"@typescript-eslint/types@npm:8.26.1, @typescript-eslint/types@npm:^8.26.0":
+  version: 8.26.1
+  resolution: "@typescript-eslint/types@npm:8.26.1"
+  checksum: 10c0/805b239b57854fc12eae9e2bec6ccab24bac1d30a762c455f22c73b777a5859c64c58b4750458bd0ab4aadd664eb95cbef091348a071975acac05b15ebea9f1b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.26.0, @typescript-eslint/typescript-estree@npm:^8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.26.0"
+"@typescript-eslint/typescript-estree@npm:8.26.1, @typescript-eslint/typescript-estree@npm:^8.26.0":
+  version: 8.26.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.26.0"
-    "@typescript-eslint/visitor-keys": "npm:8.26.0"
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -893,32 +893,32 @@ __metadata:
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/898bf7ec8ee1f3454d0e38a0bb3d7bd3cbd39f530857c9b1851650ec1647bcb6997622e86d24332d81848afd9b65ce4c080437ab1c3c023b23915a745dd0b363
+  checksum: 10c0/adc95e4735a8ded05ad35d7b4fae68c675afdd4b3531bc4a51eab5efe793cf80bc75f56dfc8022af4c0a5b316eec61f8ce6b77c2ead45fc675fea7e28cd52ade
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.26.0, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/utils@npm:8.26.0"
+"@typescript-eslint/utils@npm:8.26.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.0, @typescript-eslint/utils@npm:^8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/utils@npm:8.26.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.26.0"
-    "@typescript-eslint/types": "npm:8.26.0"
-    "@typescript-eslint/typescript-estree": "npm:8.26.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.1"
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/typescript-estree": "npm:8.26.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/594838a865d385ad5206c8b948678d4cb4010d0c9b826913968ce9e8af4d1c58b1f044de49f91d8dc36cda2ddb121ee7d2c5b53822a05f3e55002b10a42b3bfb
+  checksum: 10c0/a5cb3bdf253cc8e8474a2ed8666c0a6194abe56f44039c6623bef0459ed17d0276ed6e40c70d35bd8ec4d41bafc255e4d3025469f32ac692ba2d89e7579c2a26
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.26.0":
-  version: 8.26.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.26.0"
+"@typescript-eslint/visitor-keys@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.26.0"
+    "@typescript-eslint/types": "npm:8.26.1"
     eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/6428c1ba199d962060d43f06ba8a98b874ba6fe875a23b10e8f01550838d8be8ee689ae4da3e8b045d4c7bb01e38385e6a8ae17a9d566cf7cd21f7090b573f61
+  checksum: 10c0/51b1016d06cd2b9eac0a213de418b0a26022fd3b71478014541bfcbc2a3c4d666552390eb9c209fa9e52c868710d9f1b21a2c789d35c650239438c366a27a239
   languageName: node
   linkType: hard
 
@@ -1208,20 +1208,20 @@ __metadata:
   linkType: hard
 
 "autoprefixer@npm:^10.4.13":
-  version: 10.4.20
-  resolution: "autoprefixer@npm:10.4.20"
+  version: 10.4.21
+  resolution: "autoprefixer@npm:10.4.21"
   dependencies:
-    browserslist: "npm:^4.23.3"
-    caniuse-lite: "npm:^1.0.30001646"
+    browserslist: "npm:^4.24.4"
+    caniuse-lite: "npm:^1.0.30001702"
     fraction.js: "npm:^4.3.7"
     normalize-range: "npm:^0.1.2"
-    picocolors: "npm:^1.0.1"
+    picocolors: "npm:^1.1.1"
     postcss-value-parser: "npm:^4.2.0"
   peerDependencies:
     postcss: ^8.1.0
   bin:
     autoprefixer: bin/autoprefixer
-  checksum: 10c0/e1f00978a26e7c5b54ab12036d8c13833fad7222828fc90914771b1263f51b28c7ddb5803049de4e77696cbd02bb25cfc3634e80533025bb26c26aacdf938940
+  checksum: 10c0/de5b71d26d0baff4bbfb3d59f7cf7114a6030c9eeb66167acf49a32c5b61c68e308f1e0f869d92334436a221035d08b51cd1b2f2c4689b8d955149423c16d4d4
   languageName: node
   linkType: hard
 
@@ -1337,10 +1337,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001702
-  resolution: "caniuse-lite@npm:1.0.30001702"
-  checksum: 10c0/52d46f41a96d179fd4e387bb6b26898148c31b626ff9aba105d207d2b0f869c7cb32ac67a6e8e0aeba3f03f33145ccfbee237250dfb58dba8b6526b4dd395ac6
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
+  version: 1.0.30001703
+  resolution: "caniuse-lite@npm:1.0.30001703"
+  checksum: 10c0/ed88e318da28e9e59c4ac3a2e3c42859558b7b713aebf03696a1f916e4ed4b70734dda82be04635e2b62ec355b8639bbed829b7b12ff528d7f9cc31a3a5bea91
   languageName: node
   linkType: hard
 
@@ -1779,9 +1779,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.113
-  resolution: "electron-to-chromium@npm:1.5.113"
-  checksum: 10c0/837fe2fd26adbc4f3ad8e758d14067a14f636f9c2923b5ded8adb93426bbe3fdc83b48ddf9f2cf03be31b5becb0c31144db19c823b696fd52a7bc4583f4bde00
+  version: 1.5.115
+  resolution: "electron-to-chromium@npm:1.5.115"
+  checksum: 10c0/52429944c95118d5f1fd9d245225f64e3ab55933a7a7c975bec43bea857a285ea9d57586f5cee7978ed9f7edce8cf650354a824ed821806846493566c6be6400
   languageName: node
   linkType: hard
 
@@ -1860,8 +1860,8 @@ __metadata:
   linkType: hard
 
 "eslint-import-resolver-typescript@npm:^3.8.3":
-  version: 3.8.3
-  resolution: "eslint-import-resolver-typescript@npm:3.8.3"
+  version: 3.8.6
+  resolution: "eslint-import-resolver-typescript@npm:3.8.6"
   dependencies:
     "@nolyfill/is-core-module": "npm:1.0.39"
     debug: "npm:^4.3.7"
@@ -1879,7 +1879,7 @@ __metadata:
       optional: true
     eslint-plugin-import-x:
       optional: true
-  checksum: 10c0/886ceeab4cad14958d7c7d3432ead2486374616c8ada7925ab96e55f919f2dbbbdbe7c3081d7d238231e84699849e82930417a66e05638bcc8202e1263edddeb
+  checksum: 10c0/bc18552c2d5ff94b3d476af36906834cb2e120334832bf0f7bc6353607c3bcf6f44cf29bb3516ecfe3fd8c07c0009065d52e3588ff0c24032819b408d5963aaf
   languageName: node
   linkType: hard
 
@@ -1923,8 +1923,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-jsdoc@npm:^50.6.3":
-  version: 50.6.3
-  resolution: "eslint-plugin-jsdoc@npm:50.6.3"
+  version: 50.6.6
+  resolution: "eslint-plugin-jsdoc@npm:50.6.6"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.49.0"
     are-docs-informative: "npm:^0.0.2"
@@ -1939,7 +1939,7 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/7e0c46675b7cd2133b83969254597bbd3a15694ee2e646a4b7bc8d10babaebe52444d372195649869bcd4d82bcc1fb6b9e21f9a1d187dabd0ac3295d2d3faaff
+  checksum: 10c0/0c978b560a6f4d527a09a272ac20f60abc713258a6ea64a39a941b95cdc52428a769b4f6206edeaf73b7f0e4f9d8f96bcf0bffd7ca1b3f17351144f1af10e79b
   languageName: node
   linkType: hard
 
@@ -3043,7 +3043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -4293,17 +4293,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.26.0":
-  version: 8.26.0
-  resolution: "typescript-eslint@npm:8.26.0"
+"typescript-eslint@npm:^8.26.1":
+  version: 8.26.1
+  resolution: "typescript-eslint@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.26.0"
-    "@typescript-eslint/parser": "npm:8.26.0"
-    "@typescript-eslint/utils": "npm:8.26.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.26.1"
+    "@typescript-eslint/parser": "npm:8.26.1"
+    "@typescript-eslint/utils": "npm:8.26.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/7bf055ac2839c96d72c3c4213b5bef82ca71aba73a02922b8ba9e3bd91bb845127f32f8cb1c7b7ef6201803a7ffcf0cc6be18318b46d84296e1b1e2adbd27643
+  checksum: 10c0/92ab2e59950020eae9956e0e1fd572bc98bab0f764e63f49bfd9feab3b38edfe888712fd2df6fc43642b9be06e60288f72626d7a7cc25dcbb4c692df64cba064
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,7 +571,7 @@ __metadata:
     eslint-import-resolver-typescript: "npm:^3.8.6"
     eslint-plugin-import-x: "npm:^4.6.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
-    eslint-plugin-jsdoc: "npm:^50.6.6"
+    eslint-plugin-jsdoc: "npm:^50.6.8"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.19"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
@@ -1922,9 +1922,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.6.6":
-  version: 50.6.6
-  resolution: "eslint-plugin-jsdoc@npm:50.6.6"
+"eslint-plugin-jsdoc@npm:^50.6.8":
+  version: 50.6.8
+  resolution: "eslint-plugin-jsdoc@npm:50.6.8"
   dependencies:
     "@es-joy/jsdoccomment": "npm:~0.49.0"
     are-docs-informative: "npm:^0.0.2"
@@ -1939,7 +1939,7 @@ __metadata:
     synckit: "npm:^0.9.1"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/0c978b560a6f4d527a09a272ac20f60abc713258a6ea64a39a941b95cdc52428a769b4f6206edeaf73b7f0e4f9d8f96bcf0bffd7ca1b3f17351144f1af10e79b
+  checksum: 10c0/698006f49a10be422ac889ee6a0e33d60b326b67464c6d5e09bfa7205aca03e9e3a4030add01001f4d8e3ecd1ad2f989a0da70bd401dcbf0ea30e8b157f33c45
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,62 +227,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.30.2":
-  version: 1.30.2
-  resolution: "@eslint-react/ast@npm:1.30.2"
+"@eslint-react/ast@npm:1.31.0":
+  version: 1.31.0
+  resolution: "@eslint-react/ast@npm:1.31.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.31.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/typescript-estree": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/6a17ff119d910fa66a5e3da423fbf73869aa069fcaa7cf3dcde4b97293db1f9667e4ff5f301cce96e1d089a3f4008aac3f2242622e662b44552bea3bd8c0f017
+  checksum: 10c0/6099433dcff04948bfee58cf3e5e6095637d732064fbbd4f393feebde8c0ada300393c3b5e4ac4b4e8eb96f40c492ce14749b74702653f0be1627d9f33836eac
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.30.2":
-  version: 1.30.2
-  resolution: "@eslint-react/core@npm:1.30.2"
+"@eslint-react/core@npm:1.31.0":
+  version: 1.31.0
+  resolution: "@eslint-react/core@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/jsx": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/jsx": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/9d033519acb12b833e03c630411c6a83aa4036c291970294d75e024b3340c6ad123f4a337f4d011244e7170a2ce69af7279dc8c2466372420adcc87a5f98619b
+  checksum: 10c0/3d86d6a7c4d43b7dc38c7f43c96b03d4cf654f0a73f198f359c9a6252b895471ff12bd3cedda0abbf18f06b1464ae2c50a5998de1c459ce08ee1465185681af1
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.30.2":
-  version: 1.30.2
-  resolution: "@eslint-react/eff@npm:1.30.2"
-  checksum: 10c0/a3c321eb7704ad8ebe543b4afd446ed3fa82598bc899ae1eadea3f680fcc5cc6887ed6f043e0040cf9fe6d392f6e948788e5a9f2de2b563d545ef228146e9ccf
+"@eslint-react/eff@npm:1.31.0":
+  version: 1.31.0
+  resolution: "@eslint-react/eff@npm:1.31.0"
+  checksum: 10c0/51dd253612152943c39ed3aac09c73e9127bf40ee9dde057e14c8d3a3cdb6057ae69b1e2d18d11de181782f492af74b4c3f0a64462f7f9695449a4e8dcb07e2a
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.30.2":
-  version: 1.30.2
-  resolution: "@eslint-react/eslint-plugin@npm:1.30.2"
+"@eslint-react/eslint-plugin@npm:^1.31.0":
+  version: 1.31.0
+  resolution: "@eslint-react/eslint-plugin@npm:1.31.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
-    eslint-plugin-react-debug: "npm:1.30.2"
-    eslint-plugin-react-dom: "npm:1.30.2"
-    eslint-plugin-react-hooks-extra: "npm:1.30.2"
-    eslint-plugin-react-naming-convention: "npm:1.30.2"
-    eslint-plugin-react-web-api: "npm:1.30.2"
-    eslint-plugin-react-x: "npm:1.30.2"
+    eslint-plugin-react-debug: "npm:1.31.0"
+    eslint-plugin-react-dom: "npm:1.31.0"
+    eslint-plugin-react-hooks-extra: "npm:1.31.0"
+    eslint-plugin-react-naming-convention: "npm:1.31.0"
+    eslint-plugin-react-web-api: "npm:1.31.0"
+    eslint-plugin-react-x: "npm:1.31.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -291,49 +291,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/e0ebe0394054655994ccb51a95c54c8c2ac121e9b65bac90b7f087fa43521d193ea35df87282e48621717e4c46851f1e057b4ff5275662a8a753f577dcfc5bae
+  checksum: 10c0/f22782401a08539eba3b72c94010f6efe33ef45e194f54f07c67f9c7e4e9948e8d6cc7227c5f48967a1c318bf8ff351835cc27756cd22ddbbe55a887b8488c06
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.30.2":
-  version: 1.30.2
-  resolution: "@eslint-react/jsx@npm:1.30.2"
+"@eslint-react/jsx@npm:1.31.0":
+  version: 1.31.0
+  resolution: "@eslint-react/jsx@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/ed55982f67aa20b3cbca822966adf10ebae54b6fcd85a420fb8108e45eb47863cb7a7355c2bf0d0569ab4d55be5e5121f87173374e7deacbd2dfedf3d5dee1a8
+  checksum: 10c0/2896cdffb162d8f16a28e1586173070c92741bcd2cb04b42b187557f7fa6c7f82ff2fa255a16cda4dfd89c1ee457fb5953123d538c82b3b3c573f1dc099d498f
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.30.2":
-  version: 1.30.2
-  resolution: "@eslint-react/shared@npm:1.30.2"
+"@eslint-react/shared@npm:1.31.0":
+  version: 1.31.0
+  resolution: "@eslint-react/shared@npm:1.31.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.31.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/ecea7cb59af0c5a77ccaa5f03a9a66c21ddca213ecbb40d80ecf4e93ac238cc8766235f1ad6730a72f315ae2180cec293a7ad1ff664f1b80c2afea4ee2086f08
+  checksum: 10c0/7c4904729e61336e1aac478bf2000954b6034f267dd21859877b691cfeb3d82635b1b5d81251eebac33de9086e3818da4411d0f8ceb4e3a6f25d4f3b1f5cdc79
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.30.2":
-  version: 1.30.2
-  resolution: "@eslint-react/var@npm:1.30.2"
+"@eslint-react/var@npm:1.31.0":
+  version: 1.31.0
+  resolution: "@eslint-react/var@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/4315851456a57c2dac401d80451ce22068417f9cc981916751a4a32095c5d0733418c0994d05810663154e5b744a9a8072e72cd5e16c09a410ff6ee4487c2f72
+  checksum: 10c0/9b1c4f37fb0449728d27f5cd3309313847c304439978790864106b205bbd1ed65433108a22e7cc3ed1375850716095e6aa569854708a7f234d0cf6decbbfd08a
   languageName: node
   linkType: hard
 
@@ -555,7 +555,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.30.2"
+    "@eslint-react/eslint-plugin": "npm:^1.31.0"
     "@eslint/js": "npm:^9.21.0"
     "@tanstack/eslint-plugin-query": "npm:^5.66.1"
     "@typescript-eslint/utils": "npm:^8.26.0"
@@ -634,12 +634,12 @@ __metadata:
     "@types/webpack": "npm:^5.28.5"
     assets-webpack-plugin: "npm:^7.1.1"
     css-loader: "npm:^7.1.2"
-    css-minimizer-webpack-plugin: "npm:^7.0.0"
+    css-minimizer-webpack-plugin: "npm:^7.0.2"
     mini-css-extract-plugin: "npm:^2.9.2"
     open: "npm:^10.1.0"
     postcss: "npm:^8.5.3"
     postcss-loader: "npm:^8.1.1"
-    terser-webpack-plugin: "npm:^5.3.12"
+    terser-webpack-plugin: "npm:^5.3.14"
     typescript: "npm:~5.8.2"
     webpack: "npm:^5.98.0"
   peerDependencies:
@@ -1107,11 +1107,11 @@ __metadata:
   linkType: hard
 
 "acorn@npm:^8.14.0, acorn@npm:^8.8.2":
-  version: 8.14.0
-  resolution: "acorn@npm:8.14.0"
+  version: 8.14.1
+  resolution: "acorn@npm:8.14.1"
   bin:
     acorn: bin/acorn
-  checksum: 10c0/6d4ee461a7734b2f48836ee0fbb752903606e576cc100eb49340295129ca0b452f3ba91ddd4424a1d4406a98adfb2ebb6bd0ff4c49d7a0930c10e462719bbfd7
+  checksum: 10c0/dbd36c1ed1d2fa3550140000371fcf721578095b18777b85a79df231ca093b08edc6858d75d6e48c73e431c174dcf9214edbd7e6fa5911b93bd8abfa54e47123
   languageName: node
   linkType: hard
 
@@ -1506,14 +1506,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-minimizer-webpack-plugin@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "css-minimizer-webpack-plugin@npm:7.0.0"
+"css-minimizer-webpack-plugin@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "css-minimizer-webpack-plugin@npm:7.0.2"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
-    cssnano: "npm:^7.0.1"
+    cssnano: "npm:^7.0.4"
     jest-worker: "npm:^29.7.0"
-    postcss: "npm:^8.4.38"
+    postcss: "npm:^8.4.40"
     schema-utils: "npm:^4.2.0"
     serialize-javascript: "npm:^6.0.2"
   peerDependencies:
@@ -1531,7 +1531,7 @@ __metadata:
       optional: true
     lightningcss:
       optional: true
-  checksum: 10c0/607258ea16b753b42cbcf88b0b20c99406d7f162ad3a4da50ec3e23d1fb652d1304815c0d0c577944256c76dff3df64e1708e5c5e255318694ba8aaba7820ca3
+  checksum: 10c0/da12f3214220cec8240af7206477f1d1a0036943b704ae36c75617bda8f1905b4d0f71869eda70dfbb184d3e200be541fc5b8b65781294bde71ede1660406a5b
   languageName: node
   linkType: hard
 
@@ -1651,7 +1651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:^7.0.1":
+"cssnano@npm:^7.0.4":
   version: 7.0.6
   resolution: "cssnano@npm:7.0.6"
   dependencies:
@@ -1772,9 +1772,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.112
-  resolution: "electron-to-chromium@npm:1.5.112"
-  checksum: 10c0/fc597268d6d3d7458b55141c436802a6c51078855f021823cdb380b80ad1a69e1c2899fdfc9cffa501d47feb3791ea6a75893fe802a608c7845e979a48f5ac25
+  version: 1.5.113
+  resolution: "electron-to-chromium@npm:1.5.113"
+  checksum: 10c0/837fe2fd26adbc4f3ad8e758d14067a14f636f9c2923b5ded8adb93426bbe3fdc83b48ddf9f2cf03be31b5becb0c31144db19c823b696fd52a7bc4583f4bde00
   languageName: node
   linkType: hard
 
@@ -1936,16 +1936,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.30.2":
-  version: 1.30.2
-  resolution: "eslint-plugin-react-debug@npm:1.30.2"
+"eslint-plugin-react-debug@npm:1.31.0":
+  version: 1.31.0
+  resolution: "eslint-plugin-react-debug@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/core": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/jsx": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/core": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/jsx": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -1960,20 +1960,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/08e57f2613cd6287333a61c1c81baa7ad7fb4c82fa96b27c534643fc12fe694733a256c7b2547246f5e206ef6cf91f94560e038ed2ecd9b6a7c0b1710248ecdc
+  checksum: 10c0/2aed21da284e13972f4a7648372c8d3bcc210c637da8b2eb2984932f71f84a4476b0045807fb012afe49494b7434a93df1e6aa83bef88fc21eec9673231d45f8
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.30.2":
-  version: 1.30.2
-  resolution: "eslint-plugin-react-dom@npm:1.30.2"
+"eslint-plugin-react-dom@npm:1.31.0":
+  version: 1.31.0
+  resolution: "eslint-plugin-react-dom@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/core": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/jsx": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/core": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/jsx": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
@@ -1988,20 +1988,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/e483b5b520d02914a7aa10b0c7b9c00b4677a117de61e31da0a00641bf53922e17762fa9bf9a8e4cda70ecefd6b2714f5e5afc1378cab8351e461ea2f9497a4f
+  checksum: 10c0/ab2458b556770074e2f229d83673fc1bd82a7919206731744ba4e39b58f1f6a7f51673c7cd936db1267d8bfdfe2e8826b0f5a3184b8c94d2c12b6bdbce1ad178
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.30.2":
-  version: 1.30.2
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.30.2"
+"eslint-plugin-react-hooks-extra@npm:1.31.0":
+  version: 1.31.0
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/core": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/jsx": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/core": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/jsx": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -2016,7 +2016,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/6b9c5faa51189a644f19149c2248b42ace3beb72d7a2153feb104b90f311498f66b4b3085ca5e85ee22b799c63ae7321467e39b5a35fd0cef4400b7105a3cafc
+  checksum: 10c0/173987a0b93ee4b70548edafda643b21b4e36e536b54e3ced5b9e3bd601e57a7496161fd13778aab9182757519773294ed77a092f19a57e57dddd90c8bfb948a
   languageName: node
   linkType: hard
 
@@ -2029,16 +2029,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.30.2":
-  version: 1.30.2
-  resolution: "eslint-plugin-react-naming-convention@npm:1.30.2"
+"eslint-plugin-react-naming-convention@npm:1.31.0":
+  version: 1.31.0
+  resolution: "eslint-plugin-react-naming-convention@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/core": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/jsx": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/core": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/jsx": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -2053,7 +2053,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/51d465eeb9332531dbb42386b0976d6407dac52fed148c2dfc8cc0e8a9770285c7f1d1deab7e57bfb1a424682340d1cefe76cbe1609201e831d7cf2a5d42940d
+  checksum: 10c0/424b49c3f9e51abada9948508c2b80ff621663d935610cac3367e14105e7224d384d58eb6d0b4a44724d7bd490a75ea688a071b1aa9b2aacdacc1adf197722f1
   languageName: node
   linkType: hard
 
@@ -2066,16 +2066,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.30.2":
-  version: 1.30.2
-  resolution: "eslint-plugin-react-web-api@npm:1.30.2"
+"eslint-plugin-react-web-api@npm:1.31.0":
+  version: 1.31.0
+  resolution: "eslint-plugin-react-web-api@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/core": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/jsx": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/core": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/jsx": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
@@ -2089,20 +2089,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/18106731d0ea0b9bb3d9b7c201f4bdc7779d1ea0aed54c1c45c2fa7db4886cbd894272032fb97561f3672e97078acc7a457d953cadcd73763b9582f8b278c385
+  checksum: 10c0/a7f4ced129f652fd1ad0ede65dc672bc641ec15d2801680a1435693f0d4ad634194bdb4d2c360b059508d935db9ec8bb62860c91873ba5cd069e501b6ba15a9c
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.30.2":
-  version: 1.30.2
-  resolution: "eslint-plugin-react-x@npm:1.30.2"
+"eslint-plugin-react-x@npm:1.31.0":
+  version: 1.31.0
+  resolution: "eslint-plugin-react-x@npm:1.31.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.2"
-    "@eslint-react/core": "npm:1.30.2"
-    "@eslint-react/eff": "npm:1.30.2"
-    "@eslint-react/jsx": "npm:1.30.2"
-    "@eslint-react/shared": "npm:1.30.2"
-    "@eslint-react/var": "npm:1.30.2"
+    "@eslint-react/ast": "npm:1.31.0"
+    "@eslint-react/core": "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.31.0"
+    "@eslint-react/jsx": "npm:1.31.0"
+    "@eslint-react/shared": "npm:1.31.0"
+    "@eslint-react/var": "npm:1.31.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -2121,7 +2121,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/4aff681e6c53a0bf1e8c7901a53830fc68bf86c788c68549e45fa395abeaf62272d3354935fc7eaa4fee940df4e054579c0ea823224a747f9ebff9061f4bb7f1
+  checksum: 10c0/f692e3b496162af618d41df28f19bc7c45798118d6829403b545b29f18948a6f45370fe8a15658f9229009a5a7a6c766d2e6958d0577a29dd5a654f6f31c0a32
   languageName: node
   linkType: hard
 
@@ -3842,7 +3842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.14, postcss@npm:^8.4.33, postcss@npm:^8.4.38, postcss@npm:^8.5.3":
+"postcss@npm:^8.2.14, postcss@npm:^8.4.33, postcss@npm:^8.4.40, postcss@npm:^8.5.3":
   version: 8.5.3
   resolution: "postcss@npm:8.5.3"
   dependencies:
@@ -4198,9 +4198,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.3.11, terser-webpack-plugin@npm:^5.3.12":
-  version: 5.3.12
-  resolution: "terser-webpack-plugin@npm:5.3.12"
+"terser-webpack-plugin@npm:^5.3.11, terser-webpack-plugin@npm:^5.3.14":
+  version: 5.3.14
+  resolution: "terser-webpack-plugin@npm:5.3.14"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jest-worker: "npm:^27.4.5"
@@ -4216,7 +4216,7 @@ __metadata:
       optional: true
     uglify-js:
       optional: true
-  checksum: 10c0/b37e21bf4258603456617a88f81fa123c684f9bcd928719ada94d6b713cb3f7d726d69e642f565f67fac04ba7cab9179ebe5d5b8e2c4961afc9a7a8759ee580e
+  checksum: 10c0/9b060947241af43bd6fd728456f60e646186aef492163672a35ad49be6fbc7f63b54a7356c3f6ff40a8f83f00a977edc26f044b8e106cc611c053c8c0eaf8569
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@ __metadata:
   dependencies:
     "@eslint-react/eslint-plugin": "npm:^1.32.1"
     "@eslint/js": "npm:^9.22.0"
-    "@tanstack/eslint-plugin-query": "npm:^5.67.2"
+    "@tanstack/eslint-plugin-query": "npm:^5.68.0"
     "@typescript-eslint/utils": "npm:^8.26.1"
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
@@ -672,14 +672,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/eslint-plugin-query@npm:^5.67.2":
-  version: 5.67.2
-  resolution: "@tanstack/eslint-plugin-query@npm:5.67.2"
+"@tanstack/eslint-plugin-query@npm:^5.68.0":
+  version: 5.68.0
+  resolution: "@tanstack/eslint-plugin-query@npm:5.68.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.18.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/646d6c8621d53c6eb171aea263c104a0d46eff5578da12d2fe009d6831a94e2d611e861a3d59d34b717a87b7768daa4e70fa00d7d8336441385ff9afb47e737c
+  checksum: 10c0/4ed8e4842a513c1940c3626268ba28d3d7859970b4e5ff74f6358b064ddc9ddd76d4d18dd90ef3b85d5c95c72309747ea5e1de93504860e579da22cf414c7e8a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,7 +601,7 @@ __metadata:
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^4.2.2"
-    eslint-plugin-import-x: "npm:^4.8.1"
+    eslint-plugin-import-x: "npm:^4.9.0"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.8"
     eslint-plugin-react-hooks: "npm:^5.2.0"
@@ -2004,9 +2004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import-x@npm:^4.8.1":
-  version: 4.8.1
-  resolution: "eslint-plugin-import-x@npm:4.8.1"
+"eslint-plugin-import-x@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "eslint-plugin-import-x@npm:4.9.0"
   dependencies:
     "@types/doctrine": "npm:^0.0.9"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -2021,7 +2021,7 @@ __metadata:
     tslib: "npm:^2.8.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/53de7c1ac0ade79473f46506b9175e652d552c52df2a36df255518853ad44b8786f568613f3a7b60549a67dcf497543b38a813d7be70c7518ba00e5f28d9ebc6
+  checksum: 10c0/bc0241fd956383474a16b9e366784c861e5ebe5b956d66b5f1c3d7cfe493e5863b90d3fe306e7065b11745853ea898e4232346472928bcc4c9ecc77bac3df13f
   languageName: node
   linkType: hard
 
@@ -3012,11 +3012,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.8":
-  version: 3.3.10
-  resolution: "nanoid@npm:3.3.10"
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/34eca53d4d95cb538b05a9fa07e4b2ab941906852202edb00824c8004d71d34592704e40b0ae608bf756b1ffd91ff9359d2ea59f8d92e1a7b769e0ca46368e84
+  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,62 +255,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.35.0":
-  version: 1.35.0
-  resolution: "@eslint-react/ast@npm:1.35.0"
+"@eslint-react/ast@npm:1.36.1":
+  version: 1.36.1
+  resolution: "@eslint-react/ast@npm:1.36.1"
   dependencies:
-    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.36.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/typescript-estree": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/3bd22686f201d202c2369ca0b92272d3e06172daa073e2fba197923027de09f382370cdfc05fd68e52adc5c4b0bb4eed7c9f49f152c23e36046f50a00564731f
+  checksum: 10c0/e57575bc8fd10e98672af15aaa5ee81d3c301842297fa31895bb12dbdeb9e0c9f03e2aaa954d6bf39aad73499df67ccc38827b369a4f7a4274b14dcf6b43edb9
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.35.0":
-  version: 1.35.0
-  resolution: "@eslint-react/core@npm:1.35.0"
+"@eslint-react/core@npm:1.36.1":
+  version: 1.36.1
+  resolution: "@eslint-react/core@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/jsx": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/jsx": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/7d0ef06422373712fd57aa40d0fa98def8735cd48f95f4318daa96b980ca5a2c227a539b064209593e565a17060600b98c1d038f6cb995f9c71b2278f70c5708
+  checksum: 10c0/922e4ae8e1dba786f2d8a3dd1790058c48d7cc2b1d7f4b98ed857ad616cb697ee1316a5d7fdb35bd9c72925842d26cb2b813bad0144ca5e40f3272f4ec75fec3
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.35.0":
-  version: 1.35.0
-  resolution: "@eslint-react/eff@npm:1.35.0"
-  checksum: 10c0/01287f0848659a81820c44b646380cc6d799ae2fd16f07a49d4dce3f3c4b7483901cf7f327eb075007cb5b3edc5982e3887b3086b2aa5805b68584b2958f455e
+"@eslint-react/eff@npm:1.36.1":
+  version: 1.36.1
+  resolution: "@eslint-react/eff@npm:1.36.1"
+  checksum: 10c0/8220b2e576e5245063e4d35e777d28cf13d984269ffed2ff3def6da48514c845d10bb9cd331a3d056c11bdb17582b9dd840834b069da157aee20ec93e62fd4fe
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.35.0":
-  version: 1.35.0
-  resolution: "@eslint-react/eslint-plugin@npm:1.35.0"
+"@eslint-react/eslint-plugin@npm:^1.36.1":
+  version: 1.36.1
+  resolution: "@eslint-react/eslint-plugin@npm:1.36.1"
   dependencies:
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
-    eslint-plugin-react-debug: "npm:1.35.0"
-    eslint-plugin-react-dom: "npm:1.35.0"
-    eslint-plugin-react-hooks-extra: "npm:1.35.0"
-    eslint-plugin-react-naming-convention: "npm:1.35.0"
-    eslint-plugin-react-web-api: "npm:1.35.0"
-    eslint-plugin-react-x: "npm:1.35.0"
+    eslint-plugin-react-debug: "npm:1.36.1"
+    eslint-plugin-react-dom: "npm:1.36.1"
+    eslint-plugin-react-hooks-extra: "npm:1.36.1"
+    eslint-plugin-react-naming-convention: "npm:1.36.1"
+    eslint-plugin-react-web-api: "npm:1.36.1"
+    eslint-plugin-react-x: "npm:1.36.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -319,49 +319,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/d4987e46885c7defe00a0584d0aae103ec38228998c058a6759ce1482a5776793030b89e5ab15fc675c26d45b3ed144a1c2ffc862518dcebc15e7bd4ce07264f
+  checksum: 10c0/4818369032f4de0d222482b3a23b006f4e047f8cff06d20a2e2f435f5f0f6eb65a4d940c2d441841d2f81c5b8169d713ed56bb1d6cfa352b22753dcdd4477992
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.35.0":
-  version: 1.35.0
-  resolution: "@eslint-react/jsx@npm:1.35.0"
+"@eslint-react/jsx@npm:1.36.1":
+  version: 1.36.1
+  resolution: "@eslint-react/jsx@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/ab1b259db98616cce4f0336e159b48997bd5fea05c2c665a6e67bc3fd8d12472f1ed1c635e19c9de1c8c79baa5dbbf729f36e7fb66a14a1d7b6829be1243731c
+  checksum: 10c0/f10ba3ec9f69bce97d4d7a232cba6111467b57743dcccaff8f8bae7fccbc5694678580a64538f2183def30be2aa6c9a145627476b6fed59f69eea7eef307e547
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.35.0":
-  version: 1.35.0
-  resolution: "@eslint-react/shared@npm:1.35.0"
+"@eslint-react/shared@npm:1.36.1":
+  version: 1.36.1
+  resolution: "@eslint-react/shared@npm:1.36.1"
   dependencies:
-    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.36.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/ec40def78e9ef318acd52b4c755361c139ad0abc915e815d23884a6aa0f692f04d67554a3036bbfa32110ed8abceb558931e593f9606405a6bbe0bed18687a72
+  checksum: 10c0/f416fb7da92bb36ea573243730ddef4bd8da81a4ca7047439ee8df2b74a1ec9d0c1a93e1c5fafb9675b4dc76b2acab2f343855e29993fe82958d33df9ed7809a
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.35.0":
-  version: 1.35.0
-  resolution: "@eslint-react/var@npm:1.35.0"
+"@eslint-react/var@npm:1.36.1":
+  version: 1.36.1
+  resolution: "@eslint-react/var@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/6e518fcd473fbec492bd538bbfc079167b973f8927dc112c20310075afaf31dacc53753fa5f210be4fcdfd368fb79635dfacc8d1db94ddc544eb8e99d6c0df02
+  checksum: 10c0/8e281e08d236ddbbd56d156127f488f25190e430da9c9e3fad413629f811e0f582af551cf438355750ae4b8f1348b2ebd21ffd9ab1d79041ec592f7cf6c3562d
   languageName: node
   linkType: hard
 
@@ -594,7 +594,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.35.0"
+    "@eslint-react/eslint-plugin": "npm:^1.36.1"
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -2062,16 +2062,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.35.0":
-  version: 1.35.0
-  resolution: "eslint-plugin-react-debug@npm:1.35.0"
+"eslint-plugin-react-debug@npm:1.36.1":
+  version: 1.36.1
+  resolution: "eslint-plugin-react-debug@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/core": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/jsx": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/core": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/jsx": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2086,20 +2086,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/1af322775cda68641a635c2e7401a0c43fd1ba17c25c85c50963bc448c4d21f8fbeacf050d1ad049a288855fe240fa743b5281c40f87ef71a33c1cb243948b17
+  checksum: 10c0/84598b23a199853797f3b6d5920fd8108c3f8406a0b591ffbfb3124e058191330d59ffe4207e7da356f3448e2b032b0e107a03d28bf1baa6b96b86da15b49878
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.35.0":
-  version: 1.35.0
-  resolution: "eslint-plugin-react-dom@npm:1.35.0"
+"eslint-plugin-react-dom@npm:1.36.1":
+  version: 1.36.1
+  resolution: "eslint-plugin-react-dom@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/core": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/jsx": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/core": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/jsx": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -2114,20 +2114,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/a8abf1008c2d47264c8b3af6505cf6d95916eb21ba40c93c64ec558a4269c3093b71e6bac4fc6c36ce631e0b1f6bc0cf37414e80041fb940c33c08d0230d9535
+  checksum: 10c0/2700f30d8c586331092755cfd543b7f6134bf1b551d90b7cbab029d012e927bae40bb66e93b9cf5226b89610b5524ebc6a34b96170fa8ebf633675f3040f20c3
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.35.0":
-  version: 1.35.0
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.35.0"
+"eslint-plugin-react-hooks-extra@npm:1.36.1":
+  version: 1.36.1
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/core": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/jsx": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/core": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/jsx": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2142,7 +2142,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/5b4b46cb374c0def66ea291a585d78d67d4e2eb82c1a428ff13e49efb55e2c55c4e1910bd29070c1197309edeedaf22c33b8541d8e1dc65a0eed319094b64d6f
+  checksum: 10c0/039696789ebeb005ae4b129a908e045ded38a369140254aef9d907035bdf973a1005a3def5b4cfd38fa0d77594f080709d25d8911aba76a34f7e7a0121dfdade
   languageName: node
   linkType: hard
 
@@ -2155,16 +2155,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.35.0":
-  version: 1.35.0
-  resolution: "eslint-plugin-react-naming-convention@npm:1.35.0"
+"eslint-plugin-react-naming-convention@npm:1.36.1":
+  version: 1.36.1
+  resolution: "eslint-plugin-react-naming-convention@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/core": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/jsx": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/core": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/jsx": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2179,7 +2179,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/e04fdad50f4721b22884d2ae0724613f02c1de6d501481bb0cc5a74f2718ef3d9610dfefc94a084d745798e1a36fcaacd2baf933c363ca5374ecdddb13d49ed3
+  checksum: 10c0/128938b73f229802f3caf4f074470e3cf14f802e1ab57a9b083f6710316443485697137d96cbb13d3fd8c5c02df0caa09c911a04978bd222441e01271e227cb2
   languageName: node
   linkType: hard
 
@@ -2192,16 +2192,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.35.0":
-  version: 1.35.0
-  resolution: "eslint-plugin-react-web-api@npm:1.35.0"
+"eslint-plugin-react-web-api@npm:1.36.1":
+  version: 1.36.1
+  resolution: "eslint-plugin-react-web-api@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/core": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/jsx": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/core": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/jsx": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -2215,20 +2215,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/3208591d6fb0534e01d39ee282f51b72c4d2947fa72ac58d9a0795374314bd776542ccf2b23e3046ded87a073723c29af44c87924b0756d9ab7285c45be9fb41
+  checksum: 10c0/9f24e1f7b88af8ebdd7331eb56822885388c621fb67e46839c7c33a1a4c2eee2e48590bb77be090d794a63626f4fd8797006ce40488aa21fb6c9bb543c545f8c
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.35.0":
-  version: 1.35.0
-  resolution: "eslint-plugin-react-x@npm:1.35.0"
+"eslint-plugin-react-x@npm:1.36.1":
+  version: 1.36.1
+  resolution: "eslint-plugin-react-x@npm:1.36.1"
   dependencies:
-    "@eslint-react/ast": "npm:1.35.0"
-    "@eslint-react/core": "npm:1.35.0"
-    "@eslint-react/eff": "npm:1.35.0"
-    "@eslint-react/jsx": "npm:1.35.0"
-    "@eslint-react/shared": "npm:1.35.0"
-    "@eslint-react/var": "npm:1.35.0"
+    "@eslint-react/ast": "npm:1.36.1"
+    "@eslint-react/core": "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.36.1"
+    "@eslint-react/jsx": "npm:1.36.1"
+    "@eslint-react/shared": "npm:1.36.1"
+    "@eslint-react/var": "npm:1.36.1"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2247,7 +2247,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/6a5327fad08e2473e7f3ddd7d020ee10a6672ff4b811f41244a8c3b12379b98367de9a992f9f1bab57b14bf08b02856b657098d8aedcfd3f2d7701db7c8508d7
+  checksum: 10c0/cf0e4cb3574f86b38d1f65e01b36decba457f52745235be497a007bdeb773ffe9ce9ecabf53774774cbcf19ea5ff62874fdcdfbe6f232eafa4453c89a1739a31
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@ __metadata:
   dependencies:
     "@eslint-react/eslint-plugin": "npm:^1.31.0"
     "@eslint/js": "npm:^9.22.0"
-    "@tanstack/eslint-plugin-query": "npm:^5.66.1"
+    "@tanstack/eslint-plugin-query": "npm:^5.67.2"
     "@typescript-eslint/utils": "npm:^8.26.0"
     "@vitest/eslint-plugin": "npm:^1.1.36"
     eslint: "npm:^9.22.0"
@@ -672,14 +672,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/eslint-plugin-query@npm:^5.66.1":
-  version: 5.66.1
-  resolution: "@tanstack/eslint-plugin-query@npm:5.66.1"
+"@tanstack/eslint-plugin-query@npm:^5.67.2":
+  version: 5.67.2
+  resolution: "@tanstack/eslint-plugin-query@npm:5.67.2"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.18.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/15f0b5a15c08bf65952add24fd8d2e7322c3725b9d3c855e43db3362355afd2ca38abcb61fe2932fecda85524fdbf5bc45d31b8c16b0952995e282a8e63dd6d0
+  checksum: 10c0/646d6c8621d53c6eb171aea263c104a0d46eff5578da12d2fe009d6831a94e2d611e861a3d59d34b717a87b7768daa4e70fa00d7d8336441385ff9afb47e737c
   languageName: node
   linkType: hard
 
@@ -2902,11 +2902,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
+  version: 3.3.9
+  resolution: "nanoid@npm:3.3.9"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
+  checksum: 10c0/4515abe53db7b150cf77074558efc20d8e916d6910d557b5ce72e8bbf6f8e7554d3d7a0d180bfa65e5d8e99aa51b207aa8a3bf5f3b56233897b146d592e30b24
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,62 +255,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.36.1":
-  version: 1.36.1
-  resolution: "@eslint-react/ast@npm:1.36.1"
+"@eslint-react/ast@npm:1.37.0":
+  version: 1.37.0
+  resolution: "@eslint-react/ast@npm:1.37.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.36.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/typescript-estree": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/typescript-estree": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/e57575bc8fd10e98672af15aaa5ee81d3c301842297fa31895bb12dbdeb9e0c9f03e2aaa954d6bf39aad73499df67ccc38827b369a4f7a4274b14dcf6b43edb9
+  checksum: 10c0/17f3c1b72240b297251182f959deba9a6e05b13ee7dd1e86bee6229537ffeeb3ae9f1e2fa340fb47dc53afeb11aa2962d554d25a25f9b9caba8b6b531d52893a
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.36.1":
-  version: 1.36.1
-  resolution: "@eslint-react/core@npm:1.36.1"
+"@eslint-react/core@npm:1.37.0":
+  version: 1.37.0
+  resolution: "@eslint-react/core@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/jsx": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/type-utils": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/jsx": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/type-utils": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/922e4ae8e1dba786f2d8a3dd1790058c48d7cc2b1d7f4b98ed857ad616cb697ee1316a5d7fdb35bd9c72925842d26cb2b813bad0144ca5e40f3272f4ec75fec3
+  checksum: 10c0/0434b92e9cf2c2d2502c0a97e29a66ae6906da861b2fe10e701485bbb20575c7cea0ba72f859ca4c48c359a1aed4744f3d3d99ba3cd43a155ca3efab60852f41
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.36.1":
-  version: 1.36.1
-  resolution: "@eslint-react/eff@npm:1.36.1"
-  checksum: 10c0/8220b2e576e5245063e4d35e777d28cf13d984269ffed2ff3def6da48514c845d10bb9cd331a3d056c11bdb17582b9dd840834b069da157aee20ec93e62fd4fe
+"@eslint-react/eff@npm:1.37.0":
+  version: 1.37.0
+  resolution: "@eslint-react/eff@npm:1.37.0"
+  checksum: 10c0/85aa7db15f0e47d49e06fd55f006f0d178fcfbd740b34c9d79204bf06d9e8bcd3a7619165a615607d0aba645a45c01d082c11b4f0afd29fe895f97b7d032f0f9
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.36.1":
-  version: 1.36.1
-  resolution: "@eslint-react/eslint-plugin@npm:1.36.1"
+"@eslint-react/eslint-plugin@npm:^1.37.0":
+  version: 1.37.0
+  resolution: "@eslint-react/eslint-plugin@npm:1.37.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/type-utils": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
-    eslint-plugin-react-debug: "npm:1.36.1"
-    eslint-plugin-react-dom: "npm:1.36.1"
-    eslint-plugin-react-hooks-extra: "npm:1.36.1"
-    eslint-plugin-react-naming-convention: "npm:1.36.1"
-    eslint-plugin-react-web-api: "npm:1.36.1"
-    eslint-plugin-react-x: "npm:1.36.1"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/type-utils": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
+    eslint-plugin-react-debug: "npm:1.37.0"
+    eslint-plugin-react-dom: "npm:1.37.0"
+    eslint-plugin-react-hooks-extra: "npm:1.37.0"
+    eslint-plugin-react-naming-convention: "npm:1.37.0"
+    eslint-plugin-react-web-api: "npm:1.37.0"
+    eslint-plugin-react-x: "npm:1.37.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -319,49 +319,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/4818369032f4de0d222482b3a23b006f4e047f8cff06d20a2e2f435f5f0f6eb65a4d940c2d441841d2f81c5b8169d713ed56bb1d6cfa352b22753dcdd4477992
+  checksum: 10c0/e561e2d9af58cd0c2f34172cef0d6c6a21e2e174fee7becb9e5facb856bbd69da536a66d435f213b4d8f97f4739562d37fb1589a9c3fd1fffbc9a02c0b9074e5
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.36.1":
-  version: 1.36.1
-  resolution: "@eslint-react/jsx@npm:1.36.1"
+"@eslint-react/jsx@npm:1.37.0":
+  version: 1.37.0
+  resolution: "@eslint-react/jsx@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/f10ba3ec9f69bce97d4d7a232cba6111467b57743dcccaff8f8bae7fccbc5694678580a64538f2183def30be2aa6c9a145627476b6fed59f69eea7eef307e547
+  checksum: 10c0/76bb1624b6f402cc94081be66ec0d43b2aa0afa1285c53a161800e659ba1366a8d4731f51e5289980498410c1615773a691fe4601086e7a6c61c442dc3e02828
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.36.1":
-  version: 1.36.1
-  resolution: "@eslint-react/shared@npm:1.36.1"
+"@eslint-react/shared@npm:1.37.0":
+  version: 1.37.0
+  resolution: "@eslint-react/shared@npm:1.37.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.36.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/f416fb7da92bb36ea573243730ddef4bd8da81a4ca7047439ee8df2b74a1ec9d0c1a93e1c5fafb9675b4dc76b2acab2f343855e29993fe82958d33df9ed7809a
+  checksum: 10c0/f40803f391ca8acd00d33dc1dcfed7d49b91d767a202541beb75b7bd18701456415576345ba07e61ab0f3076d9e32a5e28c0532d11c6d4e80092423cdc118473
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.36.1":
-  version: 1.36.1
-  resolution: "@eslint-react/var@npm:1.36.1"
+"@eslint-react/var@npm:1.37.0":
+  version: 1.37.0
+  resolution: "@eslint-react/var@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/8e281e08d236ddbbd56d156127f488f25190e430da9c9e3fad413629f811e0f582af551cf438355750ae4b8f1348b2ebd21ffd9ab1d79041ec592f7cf6c3562d
+  checksum: 10c0/d6a810a5e751684c23c848697013340885df70dc0d41c9afe439d26f589c8ca4fb68511b2c4207184d2c9b3ed5bc0b55c6c7321c1ba1d3b3038a591472eda5f0
   languageName: node
   linkType: hard
 
@@ -594,7 +594,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.36.1"
+    "@eslint-react/eslint-plugin": "npm:^1.37.0"
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
@@ -888,7 +888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.27.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.1":
+"@typescript-eslint/scope-manager@npm:8.27.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.27.0":
   version: 8.27.0
   resolution: "@typescript-eslint/scope-manager@npm:8.27.0"
   dependencies:
@@ -898,7 +898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.27.0, @typescript-eslint/type-utils@npm:^8.26.1":
+"@typescript-eslint/type-utils@npm:8.27.0, @typescript-eslint/type-utils@npm:^8.27.0":
   version: 8.27.0
   resolution: "@typescript-eslint/type-utils@npm:8.27.0"
   dependencies:
@@ -913,14 +913,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.27.0, @typescript-eslint/types@npm:^8.26.1":
+"@typescript-eslint/types@npm:8.27.0, @typescript-eslint/types@npm:^8.27.0":
   version: 8.27.0
   resolution: "@typescript-eslint/types@npm:8.27.0"
   checksum: 10c0/9c5f2ba816a9baea5982feeadebe4d19f4df77ddb025a7b2307f9e1e6914076b63cbad81f7f915814e64b4d915052cf27bd79ce3e5a831340cb5ab244133941b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.27.0, @typescript-eslint/typescript-estree@npm:^8.26.1":
+"@typescript-eslint/typescript-estree@npm:8.27.0, @typescript-eslint/typescript-estree@npm:^8.27.0":
   version: 8.27.0
   resolution: "@typescript-eslint/typescript-estree@npm:8.27.0"
   dependencies:
@@ -2062,20 +2062,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.36.1":
-  version: 1.36.1
-  resolution: "eslint-plugin-react-debug@npm:1.36.1"
+"eslint-plugin-react-debug@npm:1.37.0":
+  version: 1.37.0
+  resolution: "eslint-plugin-react-debug@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/core": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/jsx": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/type-utils": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/core": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/jsx": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/type-utils": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2086,23 +2086,23 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/84598b23a199853797f3b6d5920fd8108c3f8406a0b591ffbfb3124e058191330d59ffe4207e7da356f3448e2b032b0e107a03d28bf1baa6b96b86da15b49878
+  checksum: 10c0/cbff00b7fcfcabd044a3d7281f4aa83e603fa60f1a2300e3469ab2520c63074d0c1636fde8e0826b3137a46fe98feb708f0c23c3a00b605d3c4560cd89bded6e
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.36.1":
-  version: 1.36.1
-  resolution: "eslint-plugin-react-dom@npm:1.36.1"
+"eslint-plugin-react-dom@npm:1.37.0":
+  version: 1.37.0
+  resolution: "eslint-plugin-react-dom@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/core": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/jsx": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/core": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/jsx": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
@@ -2114,24 +2114,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/2700f30d8c586331092755cfd543b7f6134bf1b551d90b7cbab029d012e927bae40bb66e93b9cf5226b89610b5524ebc6a34b96170fa8ebf633675f3040f20c3
+  checksum: 10c0/ed848fcdf61e68d5ec7bb4b7e6fff7073a2f40afe584a0c64cb8c2df4bd87f52490461f10ef2596030b7eb678a5b753843bc94632accfc84696f3ba89c6c92dd
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.36.1":
-  version: 1.36.1
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.36.1"
+"eslint-plugin-react-hooks-extra@npm:1.37.0":
+  version: 1.37.0
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/core": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/jsx": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/type-utils": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/core": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/jsx": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/type-utils": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2142,7 +2142,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/039696789ebeb005ae4b129a908e045ded38a369140254aef9d907035bdf973a1005a3def5b4cfd38fa0d77594f080709d25d8911aba76a34f7e7a0121dfdade
+  checksum: 10c0/fb2b327ab87bdbc52e6da1b18502f4e9cebbb0e0e1ccc8f8aa18564d5987cec9f230e665d7a0388079ea3ae40615e30b7423426e7f6a2c90c897f23a98708a21
   languageName: node
   linkType: hard
 
@@ -2155,20 +2155,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.36.1":
-  version: 1.36.1
-  resolution: "eslint-plugin-react-naming-convention@npm:1.36.1"
+"eslint-plugin-react-naming-convention@npm:1.37.0":
+  version: 1.37.0
+  resolution: "eslint-plugin-react-naming-convention@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/core": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/jsx": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/type-utils": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/core": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/jsx": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/type-utils": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2179,7 +2179,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/128938b73f229802f3caf4f074470e3cf14f802e1ab57a9b083f6710316443485697137d96cbb13d3fd8c5c02df0caa09c911a04978bd222441e01271e227cb2
+  checksum: 10c0/bb1c2536926e0cf41a238cb541a65726d16a9d7423861dcb8e67893f9a5dd56cb306b6cc9d1ec3d354f33604eeeacb8f1fe8c095ca16d7de52d01c2b65ac29eb
   languageName: node
   linkType: hard
 
@@ -2192,19 +2192,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.36.1":
-  version: 1.36.1
-  resolution: "eslint-plugin-react-web-api@npm:1.36.1"
+"eslint-plugin-react-web-api@npm:1.37.0":
+  version: 1.37.0
+  resolution: "eslint-plugin-react-web-api@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/core": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/jsx": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/core": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/jsx": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2215,24 +2215,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/9f24e1f7b88af8ebdd7331eb56822885388c621fb67e46839c7c33a1a4c2eee2e48590bb77be090d794a63626f4fd8797006ce40488aa21fb6c9bb543c545f8c
+  checksum: 10c0/6bf565dffbb75f04ccb9469c708c753c1e7fc1d99b551a89dd80c0e8a277d35c832d7b612cc95c03acd5bb44ed2fe471ecf10770704dee6da00898b60a4b80d0
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.36.1":
-  version: 1.36.1
-  resolution: "eslint-plugin-react-x@npm:1.36.1"
+"eslint-plugin-react-x@npm:1.37.0":
+  version: 1.37.0
+  resolution: "eslint-plugin-react-x@npm:1.37.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.36.1"
-    "@eslint-react/core": "npm:1.36.1"
-    "@eslint-react/eff": "npm:1.36.1"
-    "@eslint-react/jsx": "npm:1.36.1"
-    "@eslint-react/shared": "npm:1.36.1"
-    "@eslint-react/var": "npm:1.36.1"
-    "@typescript-eslint/scope-manager": "npm:^8.26.1"
-    "@typescript-eslint/type-utils": "npm:^8.26.1"
-    "@typescript-eslint/types": "npm:^8.26.1"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@eslint-react/ast": "npm:1.37.0"
+    "@eslint-react/core": "npm:1.37.0"
+    "@eslint-react/eff": "npm:1.37.0"
+    "@eslint-react/jsx": "npm:1.37.0"
+    "@eslint-react/shared": "npm:1.37.0"
+    "@eslint-react/var": "npm:1.37.0"
+    "@typescript-eslint/scope-manager": "npm:^8.27.0"
+    "@typescript-eslint/type-utils": "npm:^8.27.0"
+    "@typescript-eslint/types": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
@@ -2247,7 +2247,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/cf0e4cb3574f86b38d1f65e01b36decba457f52745235be497a007bdeb773ffe9ce9ecabf53774774cbcf19ea5ff62874fdcdfbe6f232eafa4453c89a1739a31
+  checksum: 10c0/70f12a37b0e2ecc02c923759ca9db1c912966427fe41a30315eac1dcaf7c5ef9a05ea0ad7193dc2f7a4021ba21ee34b1fc2b0e84e6f66fc781201ebda9a39f99
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,62 +227,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.30.1":
-  version: 1.30.1
-  resolution: "@eslint-react/ast@npm:1.30.1"
+"@eslint-react/ast@npm:1.30.2":
+  version: 1.30.2
+  resolution: "@eslint-react/ast@npm:1.30.2"
   dependencies:
-    "@eslint-react/eff": "npm:1.30.1"
+    "@eslint-react/eff": "npm:1.30.2"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/typescript-estree": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/e7c0552742ffb5ab80e1b14e061a85e89c5a0e5f9a0956354e243d75d20c002f17661730ea54fa824d6d14c22dac30db1ffe1aa5281f135a65cfefb766386ef5
+  checksum: 10c0/6a17ff119d910fa66a5e3da423fbf73869aa069fcaa7cf3dcde4b97293db1f9667e4ff5f301cce96e1d089a3f4008aac3f2242622e662b44552bea3bd8c0f017
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.30.1":
-  version: 1.30.1
-  resolution: "@eslint-react/core@npm:1.30.1"
+"@eslint-react/core@npm:1.30.2":
+  version: 1.30.2
+  resolution: "@eslint-react/core@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/jsx": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/jsx": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/fda0ef49f9d5d3d261962ff0c44a5771ca3a0b5fb92553672870496000423fdb3238449073b362c5574947726a64c7634ad01b0fe2f204f38598113785d68393
+  checksum: 10c0/9d033519acb12b833e03c630411c6a83aa4036c291970294d75e024b3340c6ad123f4a337f4d011244e7170a2ce69af7279dc8c2466372420adcc87a5f98619b
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.30.1":
-  version: 1.30.1
-  resolution: "@eslint-react/eff@npm:1.30.1"
-  checksum: 10c0/24a85ba6ecbf433fa1b3207de884a39e9ba1e2240f6f7b50a3b13d1a17d0807626b68e058b942d8b4f7e79b2b76b0d0016c956367aed77a99ff38a4e880268e7
+"@eslint-react/eff@npm:1.30.2":
+  version: 1.30.2
+  resolution: "@eslint-react/eff@npm:1.30.2"
+  checksum: 10c0/a3c321eb7704ad8ebe543b4afd446ed3fa82598bc899ae1eadea3f680fcc5cc6887ed6f043e0040cf9fe6d392f6e948788e5a9f2de2b563d545ef228146e9ccf
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.30.1":
-  version: 1.30.1
-  resolution: "@eslint-react/eslint-plugin@npm:1.30.1"
+"@eslint-react/eslint-plugin@npm:^1.30.2":
+  version: 1.30.2
+  resolution: "@eslint-react/eslint-plugin@npm:1.30.2"
   dependencies:
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
-    eslint-plugin-react-debug: "npm:1.30.1"
-    eslint-plugin-react-dom: "npm:1.30.1"
-    eslint-plugin-react-hooks-extra: "npm:1.30.1"
-    eslint-plugin-react-naming-convention: "npm:1.30.1"
-    eslint-plugin-react-web-api: "npm:1.30.1"
-    eslint-plugin-react-x: "npm:1.30.1"
+    eslint-plugin-react-debug: "npm:1.30.2"
+    eslint-plugin-react-dom: "npm:1.30.2"
+    eslint-plugin-react-hooks-extra: "npm:1.30.2"
+    eslint-plugin-react-naming-convention: "npm:1.30.2"
+    eslint-plugin-react-web-api: "npm:1.30.2"
+    eslint-plugin-react-x: "npm:1.30.2"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -291,49 +291,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/1d840ce2cb564ce41e90cf63b5f43b5bc1844ce7ba01b2ae3735da1716e2fcfab1b44611a0fda9c9b1a8f9aa77f17efcd85583cc2fcc6e68a608dbaeb4e3f391
+  checksum: 10c0/e0ebe0394054655994ccb51a95c54c8c2ac121e9b65bac90b7f087fa43521d193ea35df87282e48621717e4c46851f1e057b4ff5275662a8a753f577dcfc5bae
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.30.1":
-  version: 1.30.1
-  resolution: "@eslint-react/jsx@npm:1.30.1"
+"@eslint-react/jsx@npm:1.30.2":
+  version: 1.30.2
+  resolution: "@eslint-react/jsx@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/0c951a6de69a4950eac754be7aea370c46e3f79bedb8bf05ea784c5102a70c28138a7b5071b1c0fdce3b60fc373dad78d51cb3663850c45cc6536e4f49a82487
+  checksum: 10c0/ed55982f67aa20b3cbca822966adf10ebae54b6fcd85a420fb8108e45eb47863cb7a7355c2bf0d0569ab4d55be5e5121f87173374e7deacbd2dfedf3d5dee1a8
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.30.1":
-  version: 1.30.1
-  resolution: "@eslint-react/shared@npm:1.30.1"
+"@eslint-react/shared@npm:1.30.2":
+  version: 1.30.2
+  resolution: "@eslint-react/shared@npm:1.30.2"
   dependencies:
-    "@eslint-react/eff": "npm:1.30.1"
+    "@eslint-react/eff": "npm:1.30.2"
     "@typescript-eslint/utils": "npm:^8.26.0"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/6bf43317395dfd0f444340ac76f687641f1dc330e884c82d42e74ea91e6db2d511985e8aec9eb974415ce8773b28788d0dec3163043c5609e90cef109781455c
+  checksum: 10c0/ecea7cb59af0c5a77ccaa5f03a9a66c21ddca213ecbb40d80ecf4e93ac238cc8766235f1ad6730a72f315ae2180cec293a7ad1ff664f1b80c2afea4ee2086f08
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.30.1":
-  version: 1.30.1
-  resolution: "@eslint-react/var@npm:1.30.1"
+"@eslint-react/var@npm:1.30.2":
+  version: 1.30.2
+  resolution: "@eslint-react/var@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/42d401ef53cb350e1d8d8357b2be95527873f5d92f514d48ac86386b1e892abbfa2ded1a88ce33db1e9ba2ff5720dc372bfc351b0f6e03d79eb349a6bb382753
+  checksum: 10c0/4315851456a57c2dac401d80451ce22068417f9cc981916751a4a32095c5d0733418c0994d05810663154e5b744a9a8072e72cd5e16c09a410ff6ee4487c2f72
   languageName: node
   linkType: hard
 
@@ -555,7 +555,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.30.1"
+    "@eslint-react/eslint-plugin": "npm:^1.30.2"
     "@eslint/js": "npm:^9.21.0"
     "@tanstack/eslint-plugin-query": "npm:^5.66.1"
     "@typescript-eslint/utils": "npm:^8.26.0"
@@ -1936,16 +1936,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.30.1":
-  version: 1.30.1
-  resolution: "eslint-plugin-react-debug@npm:1.30.1"
+"eslint-plugin-react-debug@npm:1.30.2":
+  version: 1.30.2
+  resolution: "eslint-plugin-react-debug@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/core": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/jsx": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/core": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/jsx": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -1960,20 +1960,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/381dc0c8d8ba3fa3e0a68f4d5b695ca5bbffbdae7253aabe6a0a27c5294ba68dd8080bca2fc3cbae886e6f2a57a4bdd47667c2ea6eeb5f1999a1a342923c3a97
+  checksum: 10c0/08e57f2613cd6287333a61c1c81baa7ad7fb4c82fa96b27c534643fc12fe694733a256c7b2547246f5e206ef6cf91f94560e038ed2ecd9b6a7c0b1710248ecdc
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.30.1":
-  version: 1.30.1
-  resolution: "eslint-plugin-react-dom@npm:1.30.1"
+"eslint-plugin-react-dom@npm:1.30.2":
+  version: 1.30.2
+  resolution: "eslint-plugin-react-dom@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/core": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/jsx": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/core": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/jsx": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
@@ -1988,20 +1988,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/e21ea83ea33b99cb568a12ee08091dd6d1bba677e9d0188bc788572415291d5d8a4ad7fd76e29049c322694c13b06df3f4dd0d22969c164d19785e808507cec2
+  checksum: 10c0/e483b5b520d02914a7aa10b0c7b9c00b4677a117de61e31da0a00641bf53922e17762fa9bf9a8e4cda70ecefd6b2714f5e5afc1378cab8351e461ea2f9497a4f
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.30.1":
-  version: 1.30.1
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.30.1"
+"eslint-plugin-react-hooks-extra@npm:1.30.2":
+  version: 1.30.2
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/core": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/jsx": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/core": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/jsx": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -2016,7 +2016,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/8bf365a87906f82894fd94594ab9dfc1723d7b512e77157ac01f22aabd7030a42eb66566c657728220c825681a30b0b602c3ba279cea60971ba3383d4baca0b8
+  checksum: 10c0/6b9c5faa51189a644f19149c2248b42ace3beb72d7a2153feb104b90f311498f66b4b3085ca5e85ee22b799c63ae7321467e39b5a35fd0cef4400b7105a3cafc
   languageName: node
   linkType: hard
 
@@ -2029,16 +2029,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.30.1":
-  version: 1.30.1
-  resolution: "eslint-plugin-react-naming-convention@npm:1.30.1"
+"eslint-plugin-react-naming-convention@npm:1.30.2":
+  version: 1.30.2
+  resolution: "eslint-plugin-react-naming-convention@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/core": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/jsx": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/core": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/jsx": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -2053,7 +2053,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/28e9a9ddbde1cde5e3575cc64393d762737b256f02644ea52e50dd55a689a97970e5d38cc5139cf6927cfca3e9114c23eed6d3f5a11051b2b1cb60e13a036e2d
+  checksum: 10c0/51d465eeb9332531dbb42386b0976d6407dac52fed148c2dfc8cc0e8a9770285c7f1d1deab7e57bfb1a424682340d1cefe76cbe1609201e831d7cf2a5d42940d
   languageName: node
   linkType: hard
 
@@ -2066,16 +2066,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.30.1":
-  version: 1.30.1
-  resolution: "eslint-plugin-react-web-api@npm:1.30.1"
+"eslint-plugin-react-web-api@npm:1.30.2":
+  version: 1.30.2
+  resolution: "eslint-plugin-react-web-api@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/core": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/jsx": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/core": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/jsx": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
     "@typescript-eslint/utils": "npm:^8.26.0"
@@ -2089,20 +2089,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/02ac828232dc5593460087798b26c7513e354650c9a765cd8aee14ad61d34e09915be2142c1a19f03dd96ddf1afb640fb9e79f491944ccb4e85ecc74297e4c5d
+  checksum: 10c0/18106731d0ea0b9bb3d9b7c201f4bdc7779d1ea0aed54c1c45c2fa7db4886cbd894272032fb97561f3672e97078acc7a457d953cadcd73763b9582f8b278c385
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.30.1":
-  version: 1.30.1
-  resolution: "eslint-plugin-react-x@npm:1.30.1"
+"eslint-plugin-react-x@npm:1.30.2":
+  version: 1.30.2
+  resolution: "eslint-plugin-react-x@npm:1.30.2"
   dependencies:
-    "@eslint-react/ast": "npm:1.30.1"
-    "@eslint-react/core": "npm:1.30.1"
-    "@eslint-react/eff": "npm:1.30.1"
-    "@eslint-react/jsx": "npm:1.30.1"
-    "@eslint-react/shared": "npm:1.30.1"
-    "@eslint-react/var": "npm:1.30.1"
+    "@eslint-react/ast": "npm:1.30.2"
+    "@eslint-react/core": "npm:1.30.2"
+    "@eslint-react/eff": "npm:1.30.2"
+    "@eslint-react/jsx": "npm:1.30.2"
+    "@eslint-react/shared": "npm:1.30.2"
+    "@eslint-react/var": "npm:1.30.2"
     "@typescript-eslint/scope-manager": "npm:^8.26.0"
     "@typescript-eslint/type-utils": "npm:^8.26.0"
     "@typescript-eslint/types": "npm:^8.26.0"
@@ -2121,7 +2121,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/5c3e67d2d48e9dfc7fe934f76ff88f8dd2efc3025f4c87e0a35375d645ef86644eca17f3c911741bef6e15fa8a2e576d65b714f4847b2e84862bd02e8eb131d9
+  checksum: 10c0/4aff681e6c53a0bf1e8c7901a53830fc68bf86c788c68549e45fa395abeaf62272d3354935fc7eaa4fee940df4e054579c0ea823224a747f9ebff9061f4bb7f1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,6 +348,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/config-helpers@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@eslint/config-helpers@npm:0.1.0"
+  checksum: 10c0/3562b5325f42740fc83b0b92b7d13a61b383f8db064915143eec36184f09a09fad73eca6c2955ab6c248b0d04fa03c140f9af2f2c4c06770781a6b79f300a01e
+  languageName: node
+  linkType: hard
+
 "@eslint/core@npm:^0.12.0":
   version: 0.12.0
   resolution: "@eslint/core@npm:0.12.0"
@@ -374,10 +381,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.21.0, @eslint/js@npm:^9.21.0":
-  version: 9.21.0
-  resolution: "@eslint/js@npm:9.21.0"
-  checksum: 10c0/86c24a2668808995037e3f40c758335df2ae277c553ac0cf84381a1a8698f3099d8a22dd9c388947e6b7f93fcc1142f62406072faaa2b83c43ca79993fc01bb3
+"@eslint/js@npm:9.22.0, @eslint/js@npm:^9.22.0":
+  version: 9.22.0
+  resolution: "@eslint/js@npm:9.22.0"
+  checksum: 10c0/5bcd009bb579dc6c6ed760703bdd741e08a48cd9decd677aa2cf67fe66236658cb09a00185a0369f3904e5cffba9e6e0f2ff4d9ba4fdf598fcd81d34c49213a5
   languageName: node
   linkType: hard
 
@@ -556,11 +563,11 @@ __metadata:
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@eslint-react/eslint-plugin": "npm:^1.31.0"
-    "@eslint/js": "npm:^9.21.0"
+    "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.66.1"
     "@typescript-eslint/utils": "npm:^8.26.0"
     "@vitest/eslint-plugin": "npm:^1.1.36"
-    eslint: "npm:^9.21.0"
+    eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^3.8.3"
     eslint-plugin-import-x: "npm:^4.6.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
@@ -2156,13 +2163,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "eslint-scope@npm:8.2.0"
+"eslint-scope@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "eslint-scope@npm:8.3.0"
   dependencies:
     esrecurse: "npm:^4.3.0"
     estraverse: "npm:^5.2.0"
-  checksum: 10c0/8d2d58e2136d548ac7e0099b1a90d9fab56f990d86eb518de1247a7066d38c908be2f3df477a79cf60d70b30ba18735d6c6e70e9914dca2ee515a729975d70d6
+  checksum: 10c0/23bf54345573201fdf06d29efa345ab508b355492f6c6cc9e2b9f6d02b896f369b6dd5315205be94b8853809776c4d13353b85c6b531997b164ff6c3328ecf5b
   languageName: node
   linkType: hard
 
@@ -2180,16 +2187,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.21.0":
-  version: 9.21.0
-  resolution: "eslint@npm:9.21.0"
+"eslint@npm:^9.22.0":
+  version: 9.22.0
+  resolution: "eslint@npm:9.22.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.2"
+    "@eslint/config-helpers": "npm:^0.1.0"
     "@eslint/core": "npm:^0.12.0"
     "@eslint/eslintrc": "npm:^3.3.0"
-    "@eslint/js": "npm:9.21.0"
+    "@eslint/js": "npm:9.22.0"
     "@eslint/plugin-kit": "npm:^0.2.7"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -2201,7 +2209,7 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     debug: "npm:^4.3.2"
     escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.2.0"
+    eslint-scope: "npm:^8.3.0"
     eslint-visitor-keys: "npm:^4.2.0"
     espree: "npm:^10.3.0"
     esquery: "npm:^1.5.0"
@@ -2225,7 +2233,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/558edb25b440cd51825d66fed3e84f1081bd6f4cb2cf994e60ece4c5978fa0583e88b75faf187c1fc21688c4ff7072f12bf5f6d1be1e09a4d6af78cff39dc520
+  checksum: 10c0/7b5ab6f2365971c16efe97349565f75d8343347562fb23f12734c6ab2cd5e35301373a0d51e194789ddcfdfca21db7b62ff481b03d524b8169896c305b65ff48
   languageName: node
   linkType: hard
 
@@ -3966,7 +3974,7 @@ __metadata:
   dependencies:
     "@pandell/eslint-config": "workspace:packages/eslint-config"
     browserslist: "npm:^4.24.4"
-    eslint: "npm:^9.21.0"
+    eslint: "npm:^9.22.0"
     eslint-formatter-teamcity: "npm:^1.0.0"
     prettier: "npm:^3.5.3"
     typescript: "npm:~5.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,7 +566,7 @@ __metadata:
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.67.2"
     "@typescript-eslint/utils": "npm:^8.26.1"
-    "@vitest/eslint-plugin": "npm:^1.1.36"
+    "@vitest/eslint-plugin": "npm:^1.1.37"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^3.8.3"
     eslint-plugin-import-x: "npm:^4.6.1"
@@ -922,9 +922,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/eslint-plugin@npm:^1.1.36":
-  version: 1.1.36
-  resolution: "@vitest/eslint-plugin@npm:1.1.36"
+"@vitest/eslint-plugin@npm:^1.1.37":
+  version: 1.1.37
+  resolution: "@vitest/eslint-plugin@npm:1.1.37"
   peerDependencies:
     "@typescript-eslint/utils": ^8.24.0
     eslint: ">= 8.57.0"
@@ -935,7 +935,7 @@ __metadata:
       optional: true
     vitest:
       optional: true
-  checksum: 10c0/8337c8355c03eb4db25f9604cd5eb46313b4e3debeca324d7d50a920faaf5ab965bc1297dbf33c5e3946f3512f818604232b84a482db70aaa8d9732a54295dd4
+  checksum: 10c0/b63ff9959c0aa7a436f0fcab2f66bdbb2e29a4e6515962424f7b0b25c8bc898976362c67a3c6e3ac926c99b204e65cb1cac0ec526dc20e676d8cb99235664a0f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,10 +376,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@eslint/config-helpers@npm:0.1.0"
-  checksum: 10c0/3562b5325f42740fc83b0b92b7d13a61b383f8db064915143eec36184f09a09fad73eca6c2955ab6c248b0d04fa03c140f9af2f2c4c06770781a6b79f300a01e
+"@eslint/config-helpers@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@eslint/config-helpers@npm:0.2.0"
+  checksum: 10c0/743a64653e13177029108f57ab47460ded08e3412c86216a14b7e8ab2dc79c2b64be45bf55c5ef29f83692a707dc34cf1e9217e4b8b4b272a0d9b691fdaf6a2a
   languageName: node
   linkType: hard
 
@@ -392,9 +392,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "@eslint/eslintrc@npm:3.3.0"
+"@eslint/eslintrc@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@eslint/eslintrc@npm:3.3.1"
   dependencies:
     ajv: "npm:^6.12.4"
     debug: "npm:^4.3.2"
@@ -405,14 +405,14 @@ __metadata:
     js-yaml: "npm:^4.1.0"
     minimatch: "npm:^3.1.2"
     strip-json-comments: "npm:^3.1.1"
-  checksum: 10c0/215de990231b31e2fe6458f225d8cea0f5c781d3ecb0b7920703501f8cd21b3101fc5ef2f0d4f9a38865d36647b983e0e8ce8bf12fd2bcdd227fc48a5b1a43be
+  checksum: 10c0/b0e63f3bc5cce4555f791a4e487bf999173fcf27c65e1ab6e7d63634d8a43b33c3693e79f192cbff486d7df1be8ebb2bd2edc6e70ddd486cbfa84a359a3e3b41
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.22.0, @eslint/js@npm:^9.22.0":
-  version: 9.22.0
-  resolution: "@eslint/js@npm:9.22.0"
-  checksum: 10c0/5bcd009bb579dc6c6ed760703bdd741e08a48cd9decd677aa2cf67fe66236658cb09a00185a0369f3904e5cffba9e6e0f2ff4d9ba4fdf598fcd81d34c49213a5
+"@eslint/js@npm:9.23.0, @eslint/js@npm:^9.23.0":
+  version: 9.23.0
+  resolution: "@eslint/js@npm:9.23.0"
+  checksum: 10c0/4e70869372b6325389e0ab51cac6d3062689807d1cef2c3434857571422ce11dde3c62777af85c382b9f94d937127598d605d2086787f08611351bf99faded81
   languageName: node
   linkType: hard
 
@@ -595,11 +595,11 @@ __metadata:
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@eslint-react/eslint-plugin": "npm:^1.37.0"
-    "@eslint/js": "npm:^9.22.0"
+    "@eslint/js": "npm:^9.23.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
     "@typescript-eslint/utils": "npm:^8.27.0"
     "@vitest/eslint-plugin": "npm:^1.1.38"
-    eslint: "npm:^9.22.0"
+    eslint: "npm:^9.23.0"
     eslint-import-resolver-typescript: "npm:^4.2.2"
     eslint-plugin-import-x: "npm:^4.9.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
@@ -2307,17 +2307,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.22.0":
-  version: 9.22.0
-  resolution: "eslint@npm:9.22.0"
+"eslint@npm:^9.23.0":
+  version: 9.23.0
+  resolution: "eslint@npm:9.23.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.2"
-    "@eslint/config-helpers": "npm:^0.1.0"
+    "@eslint/config-helpers": "npm:^0.2.0"
     "@eslint/core": "npm:^0.12.0"
-    "@eslint/eslintrc": "npm:^3.3.0"
-    "@eslint/js": "npm:9.22.0"
+    "@eslint/eslintrc": "npm:^3.3.1"
+    "@eslint/js": "npm:9.23.0"
     "@eslint/plugin-kit": "npm:^0.2.7"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -2353,7 +2353,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/7b5ab6f2365971c16efe97349565f75d8343347562fb23f12734c6ab2cd5e35301373a0d51e194789ddcfdfca21db7b62ff481b03d524b8169896c305b65ff48
+  checksum: 10c0/9616c308dfa8d09db8ae51019c87d5d05933742214531b077bd6ab618baab3bec7938256c14dcad4dc47f5ba93feb0bc5e089f68799f076374ddea21b6a9be45
   languageName: node
   linkType: hard
 
@@ -4094,7 +4094,7 @@ __metadata:
   dependencies:
     "@pandell/eslint-config": "workspace:packages/eslint-config"
     browserslist: "npm:^4.24.4"
-    eslint: "npm:^9.22.0"
+    eslint: "npm:^9.23.0"
     eslint-formatter-teamcity: "npm:^1.0.0"
     prettier: "npm:^3.5.3"
     typescript: "npm:~5.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,7 +600,7 @@ __metadata:
     "@typescript-eslint/utils": "npm:^8.26.1"
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
-    eslint-import-resolver-typescript: "npm:^4.2.0"
+    eslint-import-resolver-typescript: "npm:^4.2.1"
     eslint-plugin-import-x: "npm:^4.8.0"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.8"
@@ -963,81 +963,81 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-darwin-arm64@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-darwin-arm64@npm:1.1.2"
+"@unrs/rspack-resolver-binding-darwin-arm64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-darwin-arm64@npm:1.2.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-darwin-x64@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-darwin-x64@npm:1.1.2"
+"@unrs/rspack-resolver-binding-darwin-x64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-darwin-x64@npm:1.2.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-freebsd-x64@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-freebsd-x64@npm:1.1.2"
+"@unrs/rspack-resolver-binding-freebsd-x64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-freebsd-x64@npm:1.2.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.1.2"
+"@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.2.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.1.2"
+"@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.2.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.1.2"
+"@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.2.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.1.2"
+"@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.2.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.1.2"
+"@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.2.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.1.2"
+"@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.2.1"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^0.2.7"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.1.2"
+"@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.2.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.1.2"
+"@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.2.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1979,13 +1979,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "eslint-import-resolver-typescript@npm:4.2.0"
+"eslint-import-resolver-typescript@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-import-resolver-typescript@npm:4.2.1"
   dependencies:
     debug: "npm:^4.4.0"
     get-tsconfig: "npm:^4.10.0"
-    rspack-resolver: "npm:^1.1.2"
+    rspack-resolver: "npm:^1.2.0"
     stable-hash: "npm:^0.0.5"
     tinyglobby: "npm:^0.2.12"
   peerDependencies:
@@ -2000,7 +2000,7 @@ __metadata:
       optional: true
     is-bun-module:
       optional: true
-  checksum: 10c0/6f9934aab6fa2a58712862b26ca4a9ed38c133312d194bdbc076418145b1e580b4d9cc78130506d8eba247857719fe5a506166456696901648ec27c63d2f3b00
+  checksum: 10c0/38fb06767a6102d0724d60210de6c2292024c97492a22124d57e4cf58a4b730ad770efcbc9dd76c11c709fc69e0146d8469911f9c690bf072682a97d0a65cfc8
   languageName: node
   linkType: hard
 
@@ -4091,21 +4091,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"rspack-resolver@npm:^1.1.0, rspack-resolver@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "rspack-resolver@npm:1.1.2"
+"rspack-resolver@npm:^1.1.0, rspack-resolver@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "rspack-resolver@npm:1.2.1"
   dependencies:
-    "@unrs/rspack-resolver-binding-darwin-arm64": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-darwin-x64": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-freebsd-x64": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-linux-arm64-gnu": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-linux-arm64-musl": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-linux-x64-gnu": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-linux-x64-musl": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-wasm32-wasi": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-win32-arm64-msvc": "npm:1.1.2"
-    "@unrs/rspack-resolver-binding-win32-x64-msvc": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-darwin-arm64": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-darwin-x64": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-freebsd-x64": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-linux-arm64-gnu": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-linux-arm64-musl": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-linux-x64-gnu": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-linux-x64-musl": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-wasm32-wasi": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-win32-arm64-msvc": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-win32-x64-msvc": "npm:1.2.1"
   dependenciesMeta:
     "@unrs/rspack-resolver-binding-darwin-arm64":
       optional: true
@@ -4129,7 +4129,7 @@ __metadata:
       optional: true
     "@unrs/rspack-resolver-binding-win32-x64-msvc":
       optional: true
-  checksum: 10c0/db95f9b970915c901edc6a3bce9119ed84c53e9618d026645fbebfb3f08793e754c82bf6d068e6da8f81c5b23a2a701ee2db5a4a4262347e371283e788291677
+  checksum: 10c0/9889d8a05ab3fcd546c2356a76bb5076b26ccb154c73d5427d3e78512704b7804273bd54b8694b152ad40de92c3b6667d02ad798d1b8baf855497ac67ea777f1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,13 +238,13 @@ __metadata:
   linkType: hard
 
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
-  version: 4.5.0
-  resolution: "@eslint-community/eslint-utils@npm:4.5.0"
+  version: 4.5.1
+  resolution: "@eslint-community/eslint-utils@npm:4.5.1"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/0fad96181bd73ef7254ba61dbbca460a41fe155880122db8852e75c1063617dc60005ff31a7354ecf9dbfcb46fce4349ceca5c1d24db036c5aa39a4bf622fafc
+  checksum: 10c0/b520ae1b7bd04531a5c5da2021071815df4717a9f7d13720e3a5ddccf5c9c619532039830811fcbae1c2f1c9d133e63af2435ee69e0fc0fabbd6d928c6800fb2
   languageName: node
   linkType: hard
 
@@ -601,7 +601,7 @@ __metadata:
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^4.2.0"
-    eslint-plugin-import-x: "npm:^4.6.1"
+    eslint-plugin-import-x: "npm:^4.8.0"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.8"
     eslint-plugin-react-hooks: "npm:^5.2.0"
@@ -888,7 +888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.26.1, @typescript-eslint/scope-manager@npm:^8.1.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.1":
+"@typescript-eslint/scope-manager@npm:8.26.1, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.1":
   version: 8.26.1
   resolution: "@typescript-eslint/scope-manager@npm:8.26.1"
   dependencies:
@@ -938,7 +938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.26.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.1":
+"@typescript-eslint/utils@npm:8.26.1, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.1":
   version: 8.26.1
   resolution: "@typescript-eslint/utils@npm:8.26.1"
   dependencies:
@@ -1458,9 +1458,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001704
-  resolution: "caniuse-lite@npm:1.0.30001704"
-  checksum: 10c0/4efa0ece51ef58e7ce7e7c8cd7b50372bcb910581a47397be5c086c046c3cd436d123b734351fb20f638c322b339198edf89b5b632ff59bdd171c74ff7f4efcf
+  version: 1.0.30001705
+  resolution: "caniuse-lite@npm:1.0.30001705"
+  checksum: 10c0/f135a9075e36cc28a66a8f37145dca2bdc45ea18fd9fae2569e781e0f7156962d4fcac374640aa6421a70c6e8d23587bf9386f5561a1fe81bbbf36055b807243
   languageName: node
   linkType: hard
 
@@ -1899,9 +1899,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.115
-  resolution: "electron-to-chromium@npm:1.5.115"
-  checksum: 10c0/52429944c95118d5f1fd9d245225f64e3ab55933a7a7c975bec43bea857a285ea9d57586f5cee7978ed9f7edce8cf650354a824ed821806846493566c6be6400
+  version: 1.5.120
+  resolution: "electron-to-chromium@npm:1.5.120"
+  checksum: 10c0/807c88e912748665a1eacd356672df88ce1ee4e6476c2bef084ee9e7ba184d7a94512a5f98218ab6deab920e78cbaec40f6cba75277c381fcc294e538a25d06d
   languageName: node
   linkType: hard
 
@@ -2004,26 +2004,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import-x@npm:^4.6.1":
-  version: 4.6.1
-  resolution: "eslint-plugin-import-x@npm:4.6.1"
+"eslint-plugin-import-x@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "eslint-plugin-import-x@npm:4.8.0"
   dependencies:
     "@types/doctrine": "npm:^0.0.9"
-    "@typescript-eslint/scope-manager": "npm:^8.1.0"
-    "@typescript-eslint/utils": "npm:^8.1.0"
-    debug: "npm:^4.3.4"
+    "@typescript-eslint/utils": "npm:^8.26.1"
+    debug: "npm:^4.4.0"
     doctrine: "npm:^3.0.0"
-    enhanced-resolve: "npm:^5.17.1"
     eslint-import-resolver-node: "npm:^0.3.9"
-    get-tsconfig: "npm:^4.7.3"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.3"
-    semver: "npm:^7.6.3"
-    stable-hash: "npm:^0.0.4"
-    tslib: "npm:^2.6.3"
+    get-tsconfig: "npm:^4.10.0"
+    picomatch: "npm:^4.0.2"
+    rspack-resolver: "npm:^1.1.0"
+    semver: "npm:^7.7.1"
+    stable-hash: "npm:^0.0.5"
+    tslib: "npm:^2.8.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/08ea85d7dc096f3998c05237c93cd14e0cb072c66ee500fa69f5ce37a81ffc8c76cf682ec53156b09f2ed2071308eb93e53bd7741e0cfd8c56e12f09ae24be82
+  checksum: 10c0/3c80239e6af0b47f463931cf9cad11bfdbe07d2aa97edf3366049356207cbe6cd53f365649d15ef8e7e0a9e57c063048c9307cf30cb4966d19bf66eb8b2b78f8
   languageName: node
   linkType: hard
 
@@ -2547,7 +2545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.10.0, get-tsconfig@npm:^4.7.3":
+"get-tsconfig@npm:^4.10.0":
   version: 4.10.0
   resolution: "get-tsconfig@npm:4.10.0"
   dependencies:
@@ -2997,7 +2995,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -3014,11 +3012,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.8":
-  version: 3.3.9
-  resolution: "nanoid@npm:3.3.9"
+  version: 3.3.10
+  resolution: "nanoid@npm:3.3.10"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/4515abe53db7b150cf77074558efc20d8e916d6910d557b5ce72e8bbf6f8e7554d3d7a0d180bfa65e5d8e99aa51b207aa8a3bf5f3b56233897b146d592e30b24
+  checksum: 10c0/34eca53d4d95cb538b05a9fa07e4b2ab941906852202edb00824c8004d71d34592704e40b0ae608bf756b1ffd91ff9359d2ea59f8d92e1a7b769e0ca46368e84
   languageName: node
   linkType: hard
 
@@ -4093,7 +4091,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"rspack-resolver@npm:^1.1.2":
+"rspack-resolver@npm:^1.1.0, rspack-resolver@npm:^1.1.2":
   version: 1.1.2
   resolution: "rspack-resolver@npm:1.1.2"
   dependencies:
@@ -4170,7 +4168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
+"semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.1":
   version: 7.7.1
   resolution: "semver@npm:7.7.1"
   bin:
@@ -4256,13 +4254,6 @@ __metadata:
   version: 3.0.21
   resolution: "spdx-license-ids@npm:3.0.21"
   checksum: 10c0/ecb24c698d8496aa9efe23e0b1f751f8a7a89faedcdfcbfabae772b546c2db46ccde8f3bc447a238eb86bbcd4f73fea88720ef3b8394f7896381bec3d7736411
-  languageName: node
-  linkType: hard
-
-"stable-hash@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "stable-hash@npm:0.0.4"
-  checksum: 10c0/53d010d2a1b014fb60d398c095f43912c353b7b44774e55222bb26fd428bc75b73d7bdfcae509ce927c23ca9c5aff2dc1bc82f191d30e57a879550bc2952bdb0
   languageName: node
   linkType: hard
 
@@ -4438,7 +4429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3":
+"tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,11 +24,11 @@ __metadata:
   linkType: hard
 
 "@babel/runtime@npm:^7.16.3":
-  version: 7.26.9
-  resolution: "@babel/runtime@npm:7.26.9"
+  version: 7.26.10
+  resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
-  checksum: 10c0/e8517131110a6ec3a7360881438b85060e49824e007f4a64b5dfa9192cf2bb5c01e84bfc109f02d822c7edb0db926928dd6b991e3ee460b483fb0fac43152d9b
+  checksum: 10c0/6dc6d88c7908f505c4f7770fb4677dfa61f68f659b943c2be1f2a99cb6680343462867abf2d49822adc435932919b36c77ac60125793e719ea8745f2073d3745
   languageName: node
   linkType: hard
 
@@ -210,13 +210,13 @@ __metadata:
   linkType: hard
 
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
-  version: 4.4.1
-  resolution: "@eslint-community/eslint-utils@npm:4.4.1"
+  version: 4.5.0
+  resolution: "@eslint-community/eslint-utils@npm:4.5.0"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/2aa0ac2fc50ff3f234408b10900ed4f1a0b19352f21346ad4cc3d83a1271481bdda11097baa45d484dd564c895e0762a27a8240be7a256b3ad47129e96528252
+  checksum: 10c0/0fad96181bd73ef7254ba61dbbca460a41fe155880122db8852e75c1063617dc60005ff31a7354ecf9dbfcb46fce4349ceca5c1d24db036c5aa39a4bf622fafc
   languageName: node
   linkType: hard
 
@@ -227,62 +227,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.31.0":
-  version: 1.31.0
-  resolution: "@eslint-react/ast@npm:1.31.0"
+"@eslint-react/ast@npm:1.32.0":
+  version: 1.32.0
+  resolution: "@eslint-react/ast@npm:1.32.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.31.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/typescript-estree": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/typescript-estree": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/6099433dcff04948bfee58cf3e5e6095637d732064fbbd4f393feebde8c0ada300393c3b5e4ac4b4e8eb96f40c492ce14749b74702653f0be1627d9f33836eac
+  checksum: 10c0/7d31f0ea73762fcdba4218243713b72d3a06c084287d9f10f25967f99184d90820e09838bbcfd25880c26d08aec8a07a798c055c148673c01220acf4b23b6a0f
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.31.0":
-  version: 1.31.0
-  resolution: "@eslint-react/core@npm:1.31.0"
+"@eslint-react/core@npm:1.32.0":
+  version: 1.32.0
+  resolution: "@eslint-react/core@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/jsx": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/type-utils": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/jsx": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/type-utils": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/3d86d6a7c4d43b7dc38c7f43c96b03d4cf654f0a73f198f359c9a6252b895471ff12bd3cedda0abbf18f06b1464ae2c50a5998de1c459ce08ee1465185681af1
+  checksum: 10c0/f0b1e04da56ea24e0dbee64f3816d532f880e86b5891be9b69ac82d2c3bcdba4919e1d55f7eec58957bba2277bdac72a6d38c05e7df2ad201adddeed692e796f
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.31.0":
-  version: 1.31.0
-  resolution: "@eslint-react/eff@npm:1.31.0"
-  checksum: 10c0/51dd253612152943c39ed3aac09c73e9127bf40ee9dde057e14c8d3a3cdb6057ae69b1e2d18d11de181782f492af74b4c3f0a64462f7f9695449a4e8dcb07e2a
+"@eslint-react/eff@npm:1.32.0":
+  version: 1.32.0
+  resolution: "@eslint-react/eff@npm:1.32.0"
+  checksum: 10c0/3950b71e7073c5ecae5ab7bc6951872eea316fc8d10d8e67b9f11d4c5ac36ae0be7788a7ff18cc58a6e92690b8f6e932c2c09d535061dc3ee47ba4841e9fb13e
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.31.0":
-  version: 1.31.0
-  resolution: "@eslint-react/eslint-plugin@npm:1.31.0"
+"@eslint-react/eslint-plugin@npm:^1.32.0":
+  version: 1.32.0
+  resolution: "@eslint-react/eslint-plugin@npm:1.32.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/type-utils": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
-    eslint-plugin-react-debug: "npm:1.31.0"
-    eslint-plugin-react-dom: "npm:1.31.0"
-    eslint-plugin-react-hooks-extra: "npm:1.31.0"
-    eslint-plugin-react-naming-convention: "npm:1.31.0"
-    eslint-plugin-react-web-api: "npm:1.31.0"
-    eslint-plugin-react-x: "npm:1.31.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/type-utils": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
+    eslint-plugin-react-debug: "npm:1.32.0"
+    eslint-plugin-react-dom: "npm:1.32.0"
+    eslint-plugin-react-hooks-extra: "npm:1.32.0"
+    eslint-plugin-react-naming-convention: "npm:1.32.0"
+    eslint-plugin-react-web-api: "npm:1.32.0"
+    eslint-plugin-react-x: "npm:1.32.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -291,49 +291,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/f22782401a08539eba3b72c94010f6efe33ef45e194f54f07c67f9c7e4e9948e8d6cc7227c5f48967a1c318bf8ff351835cc27756cd22ddbbe55a887b8488c06
+  checksum: 10c0/bde0e643e32d393ebfd0f1bba0f2f94f2278ef0e6e35d9d40d198f9c77bca7df7d4df223f9365c54e89fd43c554a71237b4bb5d8cdd0413bb8c5795f12b3696a
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.31.0":
-  version: 1.31.0
-  resolution: "@eslint-react/jsx@npm:1.31.0"
+"@eslint-react/jsx@npm:1.32.0":
+  version: 1.32.0
+  resolution: "@eslint-react/jsx@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/2896cdffb162d8f16a28e1586173070c92741bcd2cb04b42b187557f7fa6c7f82ff2fa255a16cda4dfd89c1ee457fb5953123d538c82b3b3c573f1dc099d498f
+  checksum: 10c0/4f99e78d09821692e476f188aa48c5979b4104d9400e292b7c7eaeea68872d615baaca0f2427e2c754385325c42e540bed8a66fc6043322b17f6f9c651389dc1
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.31.0":
-  version: 1.31.0
-  resolution: "@eslint-react/shared@npm:1.31.0"
+"@eslint-react/shared@npm:1.32.0":
+  version: 1.32.0
+  resolution: "@eslint-react/shared@npm:1.32.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.31.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/7c4904729e61336e1aac478bf2000954b6034f267dd21859877b691cfeb3d82635b1b5d81251eebac33de9086e3818da4411d0f8ceb4e3a6f25d4f3b1f5cdc79
+  checksum: 10c0/bc039f652fdc89a6285b8e96ebd91c2463917efc0e1d18b217b369a295b3df3fa1c687509c37518b68f9cc4d5466a3e86572b20ad77e91f3bfa83a27b6bc9a49
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.31.0":
-  version: 1.31.0
-  resolution: "@eslint-react/var@npm:1.31.0"
+"@eslint-react/var@npm:1.32.0":
+  version: 1.32.0
+  resolution: "@eslint-react/var@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/9b1c4f37fb0449728d27f5cd3309313847c304439978790864106b205bbd1ed65433108a22e7cc3ed1375850716095e6aa569854708a7f234d0cf6decbbfd08a
+  checksum: 10c0/1c405f85f31019f9e99d5ca91c5b0db5d622d1bb47f0e3935b65f22805c2ae486499dd1ec4a33f27a98d66ef6a0d54f04a6c7f13c0e81443134d423af3781f53
   languageName: node
   linkType: hard
 
@@ -562,13 +562,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.31.0"
+    "@eslint-react/eslint-plugin": "npm:^1.32.0"
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.67.2"
     "@typescript-eslint/utils": "npm:^8.26.1"
     "@vitest/eslint-plugin": "npm:^1.1.37"
     eslint: "npm:^9.22.0"
-    eslint-import-resolver-typescript: "npm:^3.8.3"
+    eslint-import-resolver-typescript: "npm:^3.8.6"
     eslint-plugin-import-x: "npm:^4.6.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.6"
@@ -766,11 +766,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 22.13.9
-  resolution: "@types/node@npm:22.13.9"
+  version: 22.13.10
+  resolution: "@types/node@npm:22.13.10"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/eb6acd04169a076631dcaab712128d492cd17a1b3f10daae4a377f3d439c860c3cd3e32f4ef221671f56183b976ac7c4089f4193457314a88675ead4663438a4
+  checksum: 10c0/a3865f9503d6f718002374f7b87efaadfae62faa499c1a33b12c527cfb9fd86f733e1a1b026b80c5a0e4a965701174bc3305595a7d36078aa1abcf09daa5dee9
   languageName: node
   linkType: hard
 
@@ -847,7 +847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.26.1, @typescript-eslint/scope-manager@npm:^8.1.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.0":
+"@typescript-eslint/scope-manager@npm:8.26.1, @typescript-eslint/scope-manager@npm:^8.1.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.26.1":
   version: 8.26.1
   resolution: "@typescript-eslint/scope-manager@npm:8.26.1"
   dependencies:
@@ -857,7 +857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.26.1, @typescript-eslint/type-utils@npm:^8.26.0":
+"@typescript-eslint/type-utils@npm:8.26.1, @typescript-eslint/type-utils@npm:^8.26.1":
   version: 8.26.1
   resolution: "@typescript-eslint/type-utils@npm:8.26.1"
   dependencies:
@@ -872,14 +872,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.26.1, @typescript-eslint/types@npm:^8.26.0":
+"@typescript-eslint/types@npm:8.26.1, @typescript-eslint/types@npm:^8.26.1":
   version: 8.26.1
   resolution: "@typescript-eslint/types@npm:8.26.1"
   checksum: 10c0/805b239b57854fc12eae9e2bec6ccab24bac1d30a762c455f22c73b777a5859c64c58b4750458bd0ab4aadd664eb95cbef091348a071975acac05b15ebea9f1b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.26.1, @typescript-eslint/typescript-estree@npm:^8.26.0":
+"@typescript-eslint/typescript-estree@npm:8.26.1, @typescript-eslint/typescript-estree@npm:^8.26.1":
   version: 8.26.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.26.1"
   dependencies:
@@ -897,7 +897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.26.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.0, @typescript-eslint/utils@npm:^8.26.1":
+"@typescript-eslint/utils@npm:8.26.1, @typescript-eslint/utils@npm:^8.1.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.1":
   version: 8.26.1
   resolution: "@typescript-eslint/utils@npm:8.26.1"
   dependencies:
@@ -1859,7 +1859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^3.8.3":
+"eslint-import-resolver-typescript@npm:^3.8.6":
   version: 3.8.6
   resolution: "eslint-import-resolver-typescript@npm:3.8.6"
   dependencies:
@@ -1943,20 +1943,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.31.0":
-  version: 1.31.0
-  resolution: "eslint-plugin-react-debug@npm:1.31.0"
+"eslint-plugin-react-debug@npm:1.32.0":
+  version: 1.32.0
+  resolution: "eslint-plugin-react-debug@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/core": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/jsx": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/type-utils": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/core": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/jsx": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/type-utils": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -1967,23 +1967,23 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/2aed21da284e13972f4a7648372c8d3bcc210c637da8b2eb2984932f71f84a4476b0045807fb012afe49494b7434a93df1e6aa83bef88fc21eec9673231d45f8
+  checksum: 10c0/1774560bb386ef2d1f4607f0583e92690a86cc0d706eab762b3576cc30f66b082e47e5d6734353bf311ead07a2c7d4d783266fa3eb3949a83c7f5e0742cbe20d
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.31.0":
-  version: 1.31.0
-  resolution: "eslint-plugin-react-dom@npm:1.31.0"
+"eslint-plugin-react-dom@npm:1.32.0":
+  version: 1.32.0
+  resolution: "eslint-plugin-react-dom@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/core": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/jsx": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/core": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/jsx": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
@@ -1995,24 +1995,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/ab2458b556770074e2f229d83673fc1bd82a7919206731744ba4e39b58f1f6a7f51673c7cd936db1267d8bfdfe2e8826b0f5a3184b8c94d2c12b6bdbce1ad178
+  checksum: 10c0/d6cec86e61cc1a47d86da0313224bea5aa64bf1af217110f915540ff5576daf4e513eb54d35020bdf8b5cfcacc4c5fa19dbf80b81d26a022691bc740a72073d2
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.31.0":
-  version: 1.31.0
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.31.0"
+"eslint-plugin-react-hooks-extra@npm:1.32.0":
+  version: 1.32.0
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/core": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/jsx": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/type-utils": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/core": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/jsx": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/type-utils": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2023,7 +2023,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/173987a0b93ee4b70548edafda643b21b4e36e536b54e3ced5b9e3bd601e57a7496161fd13778aab9182757519773294ed77a092f19a57e57dddd90c8bfb948a
+  checksum: 10c0/ee2613fa873c8b41147901e5aadff9dee1908b8aff3ef705b4326cf2a0651d3d891683bc13487196ed56a8be77f6c1a14616894b2d9876c4764440cce1a40143
   languageName: node
   linkType: hard
 
@@ -2036,20 +2036,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.31.0":
-  version: 1.31.0
-  resolution: "eslint-plugin-react-naming-convention@npm:1.31.0"
+"eslint-plugin-react-naming-convention@npm:1.32.0":
+  version: 1.32.0
+  resolution: "eslint-plugin-react-naming-convention@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/core": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/jsx": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/type-utils": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/core": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/jsx": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/type-utils": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2060,7 +2060,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/424b49c3f9e51abada9948508c2b80ff621663d935610cac3367e14105e7224d384d58eb6d0b4a44724d7bd490a75ea688a071b1aa9b2aacdacc1adf197722f1
+  checksum: 10c0/126ed45b73cca6f7c60020238ca8088770f9f9740065592c20513e6b95fc3936826d9444bccd73e146c9e7752fce958535e6382967f60ca2ae09df3a546fa60d
   languageName: node
   linkType: hard
 
@@ -2073,19 +2073,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.31.0":
-  version: 1.31.0
-  resolution: "eslint-plugin-react-web-api@npm:1.31.0"
+"eslint-plugin-react-web-api@npm:1.32.0":
+  version: 1.32.0
+  resolution: "eslint-plugin-react-web-api@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/core": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/jsx": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/core": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/jsx": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
   peerDependencies:
@@ -2096,24 +2096,24 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/a7f4ced129f652fd1ad0ede65dc672bc641ec15d2801680a1435693f0d4ad634194bdb4d2c360b059508d935db9ec8bb62860c91873ba5cd069e501b6ba15a9c
+  checksum: 10c0/bf95bad3d254da69599d7ec64849323a90293e7e1ad2efff140ea3b6c83a1ec3e259b7dbdda8e06ff5cb3bd8547de294e4981aa32a2fb838495593bf51d39c76
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.31.0":
-  version: 1.31.0
-  resolution: "eslint-plugin-react-x@npm:1.31.0"
+"eslint-plugin-react-x@npm:1.32.0":
+  version: 1.32.0
+  resolution: "eslint-plugin-react-x@npm:1.32.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.31.0"
-    "@eslint-react/core": "npm:1.31.0"
-    "@eslint-react/eff": "npm:1.31.0"
-    "@eslint-react/jsx": "npm:1.31.0"
-    "@eslint-react/shared": "npm:1.31.0"
-    "@eslint-react/var": "npm:1.31.0"
-    "@typescript-eslint/scope-manager": "npm:^8.26.0"
-    "@typescript-eslint/type-utils": "npm:^8.26.0"
-    "@typescript-eslint/types": "npm:^8.26.0"
-    "@typescript-eslint/utils": "npm:^8.26.0"
+    "@eslint-react/ast": "npm:1.32.0"
+    "@eslint-react/core": "npm:1.32.0"
+    "@eslint-react/eff": "npm:1.32.0"
+    "@eslint-react/jsx": "npm:1.32.0"
+    "@eslint-react/shared": "npm:1.32.0"
+    "@eslint-react/var": "npm:1.32.0"
+    "@typescript-eslint/scope-manager": "npm:^8.26.1"
+    "@typescript-eslint/type-utils": "npm:^8.26.1"
+    "@typescript-eslint/types": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.26.1"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
@@ -2128,7 +2128,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/f692e3b496162af618d41df28f19bc7c45798118d6829403b545b29f18948a6f45370fe8a15658f9229009a5a7a6c766d2e6958d0577a29dd5a654f6f31c0a32
+  checksum: 10c0/822383a7ae6c4a8bc00c5170c3f18b258c891c3e68f0d77a27e5bdd829b2987f6dbc39ef8b69e66bfc4bc4ea319c5045042407ff11bf8a5d6b6291021e87bbff
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,7 +597,7 @@ __metadata:
     "@eslint-react/eslint-plugin": "npm:^1.37.3"
     "@eslint/js": "npm:^9.23.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
-    "@typescript-eslint/utils": "npm:^8.27.0"
+    "@typescript-eslint/utils": "npm:^8.28.0"
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.23.0"
     eslint-import-resolver-typescript: "npm:^4.2.2"
@@ -609,7 +609,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     eslint-plugin-testing-library: "npm:^7.1.1"
     typescript: "npm:~5.8.2"
-    typescript-eslint: "npm:^8.27.0"
+    typescript-eslint: "npm:^8.28.0"
   peerDependencies:
     eslint: ">= 9"
     typescript: ">= 5"
@@ -851,15 +851,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.27.0"
+"@typescript-eslint/eslint-plugin@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.28.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.27.0"
-    "@typescript-eslint/type-utils": "npm:8.27.0"
-    "@typescript-eslint/utils": "npm:8.27.0"
-    "@typescript-eslint/visitor-keys": "npm:8.27.0"
+    "@typescript-eslint/scope-manager": "npm:8.28.0"
+    "@typescript-eslint/type-utils": "npm:8.28.0"
+    "@typescript-eslint/utils": "npm:8.28.0"
+    "@typescript-eslint/visitor-keys": "npm:8.28.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -868,64 +868,64 @@ __metadata:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/95bbab011bfe51ca657ff346e4c6cac25652c88e5188a5e74d14372dba45c3d7aa713f4c90f80ebc885d77a8be89e131e8b77c096145c90da6c251a475b125fc
+  checksum: 10c0/f01b7d231b01ec2c1cc7c40599ddceb329532f2876664a39dec9d25c0aed4cfdbef3ec07f26bac357df000d798f652af6fdb6a2481b6120e43bfa38f7c7a7c48
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/parser@npm:8.27.0"
+"@typescript-eslint/parser@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/parser@npm:8.28.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.27.0"
-    "@typescript-eslint/types": "npm:8.27.0"
-    "@typescript-eslint/typescript-estree": "npm:8.27.0"
-    "@typescript-eslint/visitor-keys": "npm:8.27.0"
+    "@typescript-eslint/scope-manager": "npm:8.28.0"
+    "@typescript-eslint/types": "npm:8.28.0"
+    "@typescript-eslint/typescript-estree": "npm:8.28.0"
+    "@typescript-eslint/visitor-keys": "npm:8.28.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/2ada98167ca5a474544fada7658d7c8d54ea4dfdd692e3d30d18b5531e50d7308a5b09d23dca651f9fe841f96075ccd18643431f4b61d0e4e7e7ccde888258e8
+  checksum: 10c0/4bde6887bbf3fe031c01e46db90f9f384a8cac2e67c2972b113a62d607db75e01db943601279aac847b9187960a038981814042cb02fd5aa27ea4613028f9313
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.27.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.27.0"
+"@typescript-eslint/scope-manager@npm:8.28.0, @typescript-eslint/scope-manager@npm:^8.15.0, @typescript-eslint/scope-manager@npm:^8.27.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.28.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.27.0"
-    "@typescript-eslint/visitor-keys": "npm:8.27.0"
-  checksum: 10c0/d87daeffb81f4e70f168c38f01c667713bda71c4545e28fcdf0792378fb3df171894ef77854c5c1a5e5a22c784ee1ccea2dd856b5baf825840710a6a74c14ac9
+    "@typescript-eslint/types": "npm:8.28.0"
+    "@typescript-eslint/visitor-keys": "npm:8.28.0"
+  checksum: 10c0/f3bd76b3f54e60f1efe108b233b2d818e44ecf0dc6422cc296542f784826caf3c66d51b8acc83d8c354980bd201e1d9aa1ea01011de96e0613d320c00e40ccfd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.27.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/type-utils@npm:8.27.0"
+"@typescript-eslint/type-utils@npm:8.28.0, @typescript-eslint/type-utils@npm:^8.0.0, @typescript-eslint/type-utils@npm:^8.27.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/type-utils@npm:8.28.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.27.0"
-    "@typescript-eslint/utils": "npm:8.27.0"
+    "@typescript-eslint/typescript-estree": "npm:8.28.0"
+    "@typescript-eslint/utils": "npm:8.28.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/f38cdc660ebcb3b71496182b9ea52301ab08a4f062558aa7061a5f0b759ae3e8f68ae250a29e74251cb52c6c56733d7dabed7002b993544cbe0933bb75d67a57
+  checksum: 10c0/b8936edc2153bf794efba39bfb06393a228217830051767360f4b691fed7c82f3831c4fc6deac6d78b90a58596e61f866c17eaee9dd793c3efda3ebdcf5a71d8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.27.0, @typescript-eslint/types@npm:^8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/types@npm:8.27.0"
-  checksum: 10c0/9c5f2ba816a9baea5982feeadebe4d19f4df77ddb025a7b2307f9e1e6914076b63cbad81f7f915814e64b4d915052cf27bd79ce3e5a831340cb5ab244133941b
+"@typescript-eslint/types@npm:8.28.0, @typescript-eslint/types@npm:^8.27.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/types@npm:8.28.0"
+  checksum: 10c0/1f95895e20dac1cf063dc93c99142fd1871e53be816bcbbee93f22a05e6b2a82ca83c20ce3a551f65555910aa0956443a23268edbb004369d0d5cb282d13c377
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.27.0, @typescript-eslint/typescript-estree@npm:^8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.27.0"
+"@typescript-eslint/typescript-estree@npm:8.28.0, @typescript-eslint/typescript-estree@npm:^8.27.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.28.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.27.0"
-    "@typescript-eslint/visitor-keys": "npm:8.27.0"
+    "@typescript-eslint/types": "npm:8.28.0"
+    "@typescript-eslint/visitor-keys": "npm:8.28.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -934,32 +934,32 @@ __metadata:
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/c04d602825ff2a7b2a89746a68b32f7052fb4ce3d2355d1f4e6f43fd064f17c3b44fb974c98838a078fdebdc35152d2ab0af34663dfca99db7a790bd3fc5d8ac
+  checksum: 10c0/97a91c95b1295926098c12e2d2c2abaa68994dc879da132dcce1e75ec9d7dee8187695eaa5241d09cbc42b5e633917b6d35c624e78e3d3ee9bda42d1318080b6
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.27.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/utils@npm:8.27.0"
+"@typescript-eslint/utils@npm:8.28.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.27.0, @typescript-eslint/utils@npm:^8.28.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/utils@npm:8.28.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.27.0"
-    "@typescript-eslint/types": "npm:8.27.0"
-    "@typescript-eslint/typescript-estree": "npm:8.27.0"
+    "@typescript-eslint/scope-manager": "npm:8.28.0"
+    "@typescript-eslint/types": "npm:8.28.0"
+    "@typescript-eslint/typescript-estree": "npm:8.28.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/dcfd5f2c17f1a33061e3ec70d0946ff23a4238aabacae3d85087165beccedf84fb8506d30848f2470e3b60ab98b230aef79c6e8b4c5d39648a37ac559ac5b1e0
+  checksum: 10c0/d3425be7f86c1245a11f0ea39136af681027797417348d8e666d38c76646945eaed7b35eb8db66372b067dee8b02a855caf2c24c040ec9c31e59681ab223b59d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.27.0":
-  version: 8.27.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.27.0"
+"@typescript-eslint/visitor-keys@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.28.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.27.0"
+    "@typescript-eslint/types": "npm:8.28.0"
     eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/d86fd4032db07123816aab3a6b8b53f840387385ab2a4d8f96b22fc76b5438fb27ac8dc42b63caf23f3d265c33e9075dbf1ce8d31f939df12f5cd077d3b10295
+  checksum: 10c0/245a78ed983fe95fbd1b0f2d4cb9e9d1d964bddc0aa3e3d6ab10c19c4273855bfb27d840bb1fd55deb7ae3078b52f26592472baf6fd2c7019a5aa3b1da974f35
   languageName: node
   linkType: hard
 
@@ -4481,17 +4481,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.27.0":
-  version: 8.27.0
-  resolution: "typescript-eslint@npm:8.27.0"
+"typescript-eslint@npm:^8.28.0":
+  version: 8.28.0
+  resolution: "typescript-eslint@npm:8.28.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.27.0"
-    "@typescript-eslint/parser": "npm:8.27.0"
-    "@typescript-eslint/utils": "npm:8.27.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.28.0"
+    "@typescript-eslint/parser": "npm:8.28.0"
+    "@typescript-eslint/utils": "npm:8.28.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/f66f8311418b12bca751e8e1c68e42c638745765be40621b65f287a15dd58d4a71e3a0f80756d5c3cc9070a93bb1745887fce2260117e19e1b70f2804cefd351
+  checksum: 10c0/bf1c1e4b2f21a95930758d5b285c39a394a50e3b6983f373413b93b80a6cb5aabc1d741780e60c63cb42ad5d645ea9c1e6d441d98174c5a2884ab88f4ac46df6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@emnapi/core@npm:1.3.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.0.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/d3be1044ad704e2c486641bc18908523490f28c7d38bd12d9c1d4ce37d39dae6c4aecd2f2eaf44c6e3bd90eaf04e0591acc440b1b038cdf43cce078a355a0ea0
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@emnapi/runtime@npm:1.3.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/060ffede50f1b619c15083312b80a9e62a5b0c87aa8c1b54854c49766c9d69f8d1d3d87bd963a647071263a320db41b25eaa50b74d6a80dcc763c23dbeaafd6c
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@emnapi/wasi-threads@npm:1.0.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/1e0c8036b8d53e9b07cc9acf021705ef6c86ab6b13e1acda7fffaf541a2d3565072afb92597419173ced9ea14f6bf32fce149106e669b5902b825e8b499e5c6c
+  languageName: node
+  linkType: hard
+
 "@es-joy/jsdoccomment@npm:~0.49.0":
   version: 0.49.0
   resolution: "@es-joy/jsdoccomment@npm:0.49.0"
@@ -518,6 +546,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "@napi-rs/wasm-runtime@npm:0.2.7"
+  dependencies:
+    "@emnapi/core": "npm:^1.3.1"
+    "@emnapi/runtime": "npm:^1.3.1"
+    "@tybys/wasm-util": "npm:^0.9.0"
+  checksum: 10c0/04a5edd79144bfa4e821a373fb6d4939f10c578c5f3633b5e67a57d0f5e36a593f595834d26654ea757bba7cd80b6c42d0d1405d6a8460c5d774e8cd5c9548a4
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -545,13 +584,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nolyfill/is-core-module@npm:1.0.39":
-  version: 1.0.39
-  resolution: "@nolyfill/is-core-module@npm:1.0.39"
-  checksum: 10c0/34ab85fdc2e0250879518841f74a30c276bca4f6c3e13526d2d1fe515e1adf6d46c25fcd5989d22ea056d76f7c39210945180b4859fc83b050e2da411aa86289
-  languageName: node
-  linkType: hard
-
 "@pandell/browserslist-config@workspace:packages/browserslist-config":
   version: 0.0.0-use.local
   resolution: "@pandell/browserslist-config@workspace:packages/browserslist-config"
@@ -568,7 +600,7 @@ __metadata:
     "@typescript-eslint/utils": "npm:^8.26.1"
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
-    eslint-import-resolver-typescript: "npm:^3.8.6"
+    eslint-import-resolver-typescript: "npm:^4.2.0"
     eslint-plugin-import-x: "npm:^4.6.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.8"
@@ -687,6 +719,15 @@ __metadata:
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
   checksum: 10c0/44907308549ce775a41c38a815f747009ac45929a45d642b836aa6b0a536e4978d30b8d7d680bbd116e9dd73b7dbe2ef0d1369dcfc2d09e83ba381e485ecbe12
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@tybys/wasm-util@npm:0.9.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f9fde5c554455019f33af6c8215f1a1435028803dc2a2825b077d812bed4209a1a64444a4ca0ce2ea7e1175c8d88e2f9173a36a33c199e8a5c671aa31de8242d
   languageName: node
   linkType: hard
 
@@ -919,6 +960,85 @@ __metadata:
     "@typescript-eslint/types": "npm:8.26.1"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/51b1016d06cd2b9eac0a213de418b0a26022fd3b71478014541bfcbc2a3c4d666552390eb9c209fa9e52c868710d9f1b21a2c789d35c650239438c366a27a239
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-darwin-arm64@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-darwin-arm64@npm:1.1.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-darwin-x64@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-darwin-x64@npm:1.1.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-freebsd-x64@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-freebsd-x64@npm:1.1.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.1.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.1.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.1.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.1.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.1.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.1.2"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^0.2.7"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.1.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.1.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1688,7 +1808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6, debug@npm:^4.3.7":
+"debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -1785,7 +1905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.15.0, enhanced-resolve@npm:^5.17.1":
+"enhanced-resolve@npm:^5.17.1":
   version: 5.18.1
   resolution: "enhanced-resolve@npm:5.18.1"
   dependencies:
@@ -1859,27 +1979,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^3.8.6":
-  version: 3.8.6
-  resolution: "eslint-import-resolver-typescript@npm:3.8.6"
+"eslint-import-resolver-typescript@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "eslint-import-resolver-typescript@npm:4.2.0"
   dependencies:
-    "@nolyfill/is-core-module": "npm:1.0.39"
-    debug: "npm:^4.3.7"
-    enhanced-resolve: "npm:^5.15.0"
+    debug: "npm:^4.4.0"
     get-tsconfig: "npm:^4.10.0"
-    is-bun-module: "npm:^1.0.2"
-    stable-hash: "npm:^0.0.4"
+    rspack-resolver: "npm:^1.1.2"
+    stable-hash: "npm:^0.0.5"
     tinyglobby: "npm:^0.2.12"
   peerDependencies:
     eslint: "*"
     eslint-plugin-import: "*"
     eslint-plugin-import-x: "*"
+    is-bun-module: "*"
   peerDependenciesMeta:
     eslint-plugin-import:
       optional: true
     eslint-plugin-import-x:
       optional: true
-  checksum: 10c0/bc18552c2d5ff94b3d476af36906834cb2e120334832bf0f7bc6353607c3bcf6f44cf29bb3516ecfe3fd8c07c0009065d52e3588ff0c24032819b408d5963aaf
+    is-bun-module:
+      optional: true
+  checksum: 10c0/6f9934aab6fa2a58712862b26ca4a9ed38c133312d194bdbc076418145b1e580b4d9cc78130506d8eba247857719fe5a506166456696901648ec27c63d2f3b00
   languageName: node
   linkType: hard
 
@@ -2534,15 +2655,6 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: 10c0/e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
-  languageName: node
-  linkType: hard
-
-"is-bun-module@npm:^1.0.2":
-  version: 1.3.0
-  resolution: "is-bun-module@npm:1.3.0"
-  dependencies:
-    semver: "npm:^7.6.3"
-  checksum: 10c0/2966744188fcd28e0123c52158c7073973f88babfa9ab04e2846ec5862d6b0f8f398df6413429d930f7c5ee6111ce2cbfb3eb8652d9ec42d4a37dc5089a866fb
   languageName: node
   linkType: hard
 
@@ -3981,6 +4093,48 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"rspack-resolver@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "rspack-resolver@npm:1.1.2"
+  dependencies:
+    "@unrs/rspack-resolver-binding-darwin-arm64": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-darwin-x64": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-freebsd-x64": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-linux-arm64-gnu": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-linux-arm64-musl": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-linux-x64-gnu": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-linux-x64-musl": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-wasm32-wasi": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-win32-arm64-msvc": "npm:1.1.2"
+    "@unrs/rspack-resolver-binding-win32-x64-msvc": "npm:1.1.2"
+  dependenciesMeta:
+    "@unrs/rspack-resolver-binding-darwin-arm64":
+      optional: true
+    "@unrs/rspack-resolver-binding-darwin-x64":
+      optional: true
+    "@unrs/rspack-resolver-binding-freebsd-x64":
+      optional: true
+    "@unrs/rspack-resolver-binding-linux-arm-gnueabihf":
+      optional: true
+    "@unrs/rspack-resolver-binding-linux-arm64-gnu":
+      optional: true
+    "@unrs/rspack-resolver-binding-linux-arm64-musl":
+      optional: true
+    "@unrs/rspack-resolver-binding-linux-x64-gnu":
+      optional: true
+    "@unrs/rspack-resolver-binding-linux-x64-musl":
+      optional: true
+    "@unrs/rspack-resolver-binding-wasm32-wasi":
+      optional: true
+    "@unrs/rspack-resolver-binding-win32-arm64-msvc":
+      optional: true
+    "@unrs/rspack-resolver-binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/db95f9b970915c901edc6a3bce9119ed84c53e9618d026645fbebfb3f08793e754c82bf6d068e6da8f81c5b23a2a701ee2db5a4a4262347e371283e788291677
+  languageName: node
+  linkType: hard
+
 "run-applescript@npm:^7.0.0":
   version: 7.0.0
   resolution: "run-applescript@npm:7.0.0"
@@ -4109,6 +4263,13 @@ __metadata:
   version: 0.0.4
   resolution: "stable-hash@npm:0.0.4"
   checksum: 10c0/53d010d2a1b014fb60d398c095f43912c353b7b44774e55222bb26fd428bc75b73d7bdfcae509ce927c23ca9c5aff2dc1bc82f191d30e57a879550bc2952bdb0
+  languageName: node
+  linkType: hard
+
+"stable-hash@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "stable-hash@npm:0.0.5"
+  checksum: 10c0/ca670cb6d172f1c834950e4ec661e2055885df32fee3ebf3647c5df94993b7c2666a5dbc1c9a62ee11fc5c24928579ec5e81bb5ad31971d355d5a341aab493b3
   languageName: node
   linkType: hard
 
@@ -4277,7 +4438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.6.2, tslib@npm:^2.6.3":
+"tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,7 +566,7 @@ __metadata:
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.67.2"
     "@typescript-eslint/utils": "npm:^8.26.1"
-    "@vitest/eslint-plugin": "npm:^1.1.37"
+    "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^3.8.6"
     eslint-plugin-import-x: "npm:^4.6.1"
@@ -922,9 +922,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/eslint-plugin@npm:^1.1.37":
-  version: 1.1.37
-  resolution: "@vitest/eslint-plugin@npm:1.1.37"
+"@vitest/eslint-plugin@npm:^1.1.38":
+  version: 1.1.38
+  resolution: "@vitest/eslint-plugin@npm:1.1.38"
   peerDependencies:
     "@typescript-eslint/utils": ^8.24.0
     eslint: ">= 8.57.0"
@@ -935,7 +935,7 @@ __metadata:
       optional: true
     vitest:
       optional: true
-  checksum: 10c0/b63ff9959c0aa7a436f0fcab2f66bdbb2e29a4e6515962424f7b0b25c8bc898976362c67a3c6e3ac926c99b204e65cb1cac0ec526dc20e676d8cb99235664a0f
+  checksum: 10c0/b5bdde57dbea90a35d0c37d29b1574d4f0fab8da19a52570f33a51188acbdcb9565f69f24e79010d3351f78591449896d326030e299736483ff5729b07d76904
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,62 +227,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:1.32.1":
-  version: 1.32.1
-  resolution: "@eslint-react/ast@npm:1.32.1"
+"@eslint-react/ast@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@eslint-react/ast@npm:1.35.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.35.0"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/typescript-estree": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/4beb4df6380f91c5341379856e870e0778174c23ade9255c5d6bc2573cc3a77ef9021802aa4e9b63eecde222911e93008ac9ba40b68196ae71e11176123c4d4e
+  checksum: 10c0/3bd22686f201d202c2369ca0b92272d3e06172daa073e2fba197923027de09f382370cdfc05fd68e52adc5c4b0bb4eed7c9f49f152c23e36046f50a00564731f
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:1.32.1":
-  version: 1.32.1
-  resolution: "@eslint-react/core@npm:1.32.1"
+"@eslint-react/core@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@eslint-react/core@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/jsx": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/jsx": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/3dc65c773f4414556a15d05d013d1ac9e3fcab2723035440a2354b664169617f495d1ec8775158aadaa9df8800b6173fed75351339881c25dee523f8d4830463
+  checksum: 10c0/7d0ef06422373712fd57aa40d0fa98def8735cd48f95f4318daa96b980ca5a2c227a539b064209593e565a17060600b98c1d038f6cb995f9c71b2278f70c5708
   languageName: node
   linkType: hard
 
-"@eslint-react/eff@npm:1.32.1":
-  version: 1.32.1
-  resolution: "@eslint-react/eff@npm:1.32.1"
-  checksum: 10c0/a9dd84010e6a62a5695e22f67ed03c0ede3b3e35be811ebecd97630b5dd8206606fb8b6307b1c9f165e6c36a3665b0172ea633d4d27af8eab4e9abbf4a48f96e
+"@eslint-react/eff@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@eslint-react/eff@npm:1.35.0"
+  checksum: 10c0/01287f0848659a81820c44b646380cc6d799ae2fd16f07a49d4dce3f3c4b7483901cf7f327eb075007cb5b3edc5982e3887b3086b2aa5805b68584b2958f455e
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^1.32.1":
-  version: 1.32.1
-  resolution: "@eslint-react/eslint-plugin@npm:1.32.1"
+"@eslint-react/eslint-plugin@npm:^1.35.0":
+  version: 1.35.0
+  resolution: "@eslint-react/eslint-plugin@npm:1.35.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
-    eslint-plugin-react-debug: "npm:1.32.1"
-    eslint-plugin-react-dom: "npm:1.32.1"
-    eslint-plugin-react-hooks-extra: "npm:1.32.1"
-    eslint-plugin-react-naming-convention: "npm:1.32.1"
-    eslint-plugin-react-web-api: "npm:1.32.1"
-    eslint-plugin-react-x: "npm:1.32.1"
+    eslint-plugin-react-debug: "npm:1.35.0"
+    eslint-plugin-react-dom: "npm:1.35.0"
+    eslint-plugin-react-hooks-extra: "npm:1.35.0"
+    eslint-plugin-react-naming-convention: "npm:1.35.0"
+    eslint-plugin-react-web-api: "npm:1.35.0"
+    eslint-plugin-react-x: "npm:1.35.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ^4.9.5 || ^5.3.3
@@ -291,49 +291,49 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/c22568cb8b55b8e4f05e0db43197773496006959983d2d44b8cd9fc3e5b11a9b37be1f16ef9e78fcd4a0e87ea19d43429e9c2b2958d663327a12fdc8d4d71769
+  checksum: 10c0/d4987e46885c7defe00a0584d0aae103ec38228998c058a6759ce1482a5776793030b89e5ab15fc675c26d45b3ed144a1c2ffc862518dcebc15e7bd4ce07264f
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:1.32.1":
-  version: 1.32.1
-  resolution: "@eslint-react/jsx@npm:1.32.1"
+"@eslint-react/jsx@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@eslint-react/jsx@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/9f1dd15f2a5dede5e86d580cd5ac8519e6ed5707cec1afa6dfe4c875419f5fb325b1e7139ad68347703e082cfb89b6d0b9ace3833a52dff18f22d4925ac4857a
+  checksum: 10c0/ab1b259db98616cce4f0336e159b48997bd5fea05c2c665a6e67bc3fd8d12472f1ed1c635e19c9de1c8c79baa5dbbf729f36e7fb66a14a1d7b6829be1243731c
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:1.32.1":
-  version: 1.32.1
-  resolution: "@eslint-react/shared@npm:1.32.1"
+"@eslint-react/shared@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@eslint-react/shared@npm:1.35.0"
   dependencies:
-    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/eff": "npm:1.35.0"
     "@typescript-eslint/utils": "npm:^8.26.1"
     picomatch: "npm:^4.0.2"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/745f9459d2adaf9105a5093e4cc60256c9627c1fa72f9e1afa5d2834224d3995d18b7990b46dc55109be030399fab49f7786f030c258a6dab24d0799c710ed0b
+  checksum: 10c0/ec40def78e9ef318acd52b4c755361c139ad0abc915e815d23884a6aa0f692f04d67554a3036bbfa32110ed8abceb558931e593f9606405a6bbe0bed18687a72
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:1.32.1":
-  version: 1.32.1
-  resolution: "@eslint-react/var@npm:1.32.1"
+"@eslint-react/var@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@eslint-react/var@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
     string-ts: "npm:^2.2.1"
     ts-pattern: "npm:^5.6.2"
-  checksum: 10c0/582b762337ab2f497b75883994bb29d155e3ee2770b2f36771e4cf1e4e7f7ef6a298037d603b4c61b1af78603d9f2eafe6386dd35740c5e6c18e9fbb49a576b9
+  checksum: 10c0/6e518fcd473fbec492bd538bbfc079167b973f8927dc112c20310075afaf31dacc53753fa5f210be4fcdfd368fb79635dfacc8d1db94ddc544eb8e99d6c0df02
   languageName: node
   linkType: hard
 
@@ -562,7 +562,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pandell/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint-react/eslint-plugin": "npm:^1.32.1"
+    "@eslint-react/eslint-plugin": "npm:^1.35.0"
     "@eslint/js": "npm:^9.22.0"
     "@tanstack/eslint-plugin-query": "npm:^5.68.0"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -1943,16 +1943,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-debug@npm:1.32.1":
-  version: 1.32.1
-  resolution: "eslint-plugin-react-debug@npm:1.32.1"
+"eslint-plugin-react-debug@npm:1.35.0":
+  version: 1.35.0
+  resolution: "eslint-plugin-react-debug@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/core": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/jsx": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/core": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/jsx": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -1967,20 +1967,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/8694126c581c914ab18615e6c65ac8dbd5a4fa323dcaf45f4f31c08d6bedb463bf6b761281a9dcf1fe5e05acb942a42c5b4b74f50fe086cc68a5559b43b686f8
+  checksum: 10c0/1af322775cda68641a635c2e7401a0c43fd1ba17c25c85c50963bc448c4d21f8fbeacf050d1ad049a288855fe240fa743b5281c40f87ef71a33c1cb243948b17
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:1.32.1":
-  version: 1.32.1
-  resolution: "eslint-plugin-react-dom@npm:1.32.1"
+"eslint-plugin-react-dom@npm:1.35.0":
+  version: 1.35.0
+  resolution: "eslint-plugin-react-dom@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/core": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/jsx": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/core": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/jsx": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -1995,20 +1995,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/632dece4d59a7793ed21ce0e0a42d8e338dfa64bee6083b4bbfbd201fb9a8d48666dc1bde547d44e37b0a9d9711c0fbaf73130219c4088c1c4296c2e058469dc
+  checksum: 10c0/a8abf1008c2d47264c8b3af6505cf6d95916eb21ba40c93c64ec558a4269c3093b71e6bac4fc6c36ce631e0b1f6bc0cf37414e80041fb940c33c08d0230d9535
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks-extra@npm:1.32.1":
-  version: 1.32.1
-  resolution: "eslint-plugin-react-hooks-extra@npm:1.32.1"
+"eslint-plugin-react-hooks-extra@npm:1.35.0":
+  version: 1.35.0
+  resolution: "eslint-plugin-react-hooks-extra@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/core": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/jsx": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/core": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/jsx": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2023,7 +2023,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/2e727a9f51545d3f4328033804985eb7506af72241f7b7a99679fbc725d8950bd2bb0fe96fd69a1ab456a48a860bb6fc7001f4ccbc6e5806c9d353e6bd169b27
+  checksum: 10c0/5b4b46cb374c0def66ea291a585d78d67d4e2eb82c1a428ff13e49efb55e2c55c4e1910bd29070c1197309edeedaf22c33b8541d8e1dc65a0eed319094b64d6f
   languageName: node
   linkType: hard
 
@@ -2036,16 +2036,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:1.32.1":
-  version: 1.32.1
-  resolution: "eslint-plugin-react-naming-convention@npm:1.32.1"
+"eslint-plugin-react-naming-convention@npm:1.35.0":
+  version: 1.35.0
+  resolution: "eslint-plugin-react-naming-convention@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/core": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/jsx": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/core": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/jsx": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2060,7 +2060,7 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/82ec77c093ea3424da1f58812db132633a98aafcab021a32345815959307f62a744cbbe58a0825d2c9a9cade8883e853f38d6305db765d8863703f5d55b2c983
+  checksum: 10c0/e04fdad50f4721b22884d2ae0724613f02c1de6d501481bb0cc5a74f2718ef3d9610dfefc94a084d745798e1a36fcaacd2baf933c363ca5374ecdddb13d49ed3
   languageName: node
   linkType: hard
 
@@ -2073,16 +2073,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:1.32.1":
-  version: 1.32.1
-  resolution: "eslint-plugin-react-web-api@npm:1.32.1"
+"eslint-plugin-react-web-api@npm:1.35.0":
+  version: 1.35.0
+  resolution: "eslint-plugin-react-web-api@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/core": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/jsx": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/core": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/jsx": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
     "@typescript-eslint/utils": "npm:^8.26.1"
@@ -2096,20 +2096,20 @@ __metadata:
       optional: false
     typescript:
       optional: true
-  checksum: 10c0/432f0200c0ce9b1df6ee3124d3cf4ecade0e976999ef76ff690af67423e0f5e9b081288273d840417e2614958867fd8cbc9f1a655025aa4f265f9475931b2098
+  checksum: 10c0/3208591d6fb0534e01d39ee282f51b72c4d2947fa72ac58d9a0795374314bd776542ccf2b23e3046ded87a073723c29af44c87924b0756d9ab7285c45be9fb41
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:1.32.1":
-  version: 1.32.1
-  resolution: "eslint-plugin-react-x@npm:1.32.1"
+"eslint-plugin-react-x@npm:1.35.0":
+  version: 1.35.0
+  resolution: "eslint-plugin-react-x@npm:1.35.0"
   dependencies:
-    "@eslint-react/ast": "npm:1.32.1"
-    "@eslint-react/core": "npm:1.32.1"
-    "@eslint-react/eff": "npm:1.32.1"
-    "@eslint-react/jsx": "npm:1.32.1"
-    "@eslint-react/shared": "npm:1.32.1"
-    "@eslint-react/var": "npm:1.32.1"
+    "@eslint-react/ast": "npm:1.35.0"
+    "@eslint-react/core": "npm:1.35.0"
+    "@eslint-react/eff": "npm:1.35.0"
+    "@eslint-react/jsx": "npm:1.35.0"
+    "@eslint-react/shared": "npm:1.35.0"
+    "@eslint-react/var": "npm:1.35.0"
     "@typescript-eslint/scope-manager": "npm:^8.26.1"
     "@typescript-eslint/type-utils": "npm:^8.26.1"
     "@typescript-eslint/types": "npm:^8.26.1"
@@ -2128,7 +2128,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/d796da9ec70d549f6d375df0a9fb9594ce6d5d51ef3d5476f573d27e9a2830aa34d2587b1a65ec4e31f4a787d8ece1367dfa9e55bfbfa328c4b5bdab71b6e587
+  checksum: 10c0/6a5327fad08e2473e7f3ddd7d020ee10a6672ff4b811f41244a8c3b12379b98367de9a992f9f1bab57b14bf08b02856b657098d8aedcfd3f2d7701db7c8508d7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,7 +601,7 @@ __metadata:
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
     eslint-import-resolver-typescript: "npm:^4.2.2"
-    eslint-plugin-import-x: "npm:^4.9.0"
+    eslint-plugin-import-x: "npm:^4.9.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.8"
     eslint-plugin-react-hooks: "npm:^5.2.0"
@@ -691,9 +691,9 @@ __metadata:
   linkType: soft
 
 "@pkgr/core@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "@pkgr/core@npm:0.1.1"
-  checksum: 10c0/3f7536bc7f57320ab2cf96f8973664bef624710c403357429fbf680a5c3b4843c1dbd389bb43daa6b1f6f1f007bb082f5abcb76bb2b5dc9f421647743b71d3d8
+  version: 0.1.2
+  resolution: "@pkgr/core@npm:0.1.2"
+  checksum: 10c0/fd4acc154c8f1b5c544b6dd152b7ce68f6cbb8b92e9abf2e5d756d6e95052d08d0d693a668dea67af1386d62635b50adfe463cce03c5620402b468498cc7592f
   languageName: node
   linkType: hard
 
@@ -938,7 +938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.27.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.26.1, @typescript-eslint/utils@npm:^8.27.0":
+"@typescript-eslint/utils@npm:8.27.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.18.1, @typescript-eslint/utils@npm:^8.27.0":
   version: 8.27.0
   resolution: "@typescript-eslint/utils@npm:8.27.0"
   dependencies:
@@ -1899,9 +1899,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.120
-  resolution: "electron-to-chromium@npm:1.5.120"
-  checksum: 10c0/807c88e912748665a1eacd356672df88ce1ee4e6476c2bef084ee9e7ba184d7a94512a5f98218ab6deab920e78cbaec40f6cba75277c381fcc294e538a25d06d
+  version: 1.5.123
+  resolution: "electron-to-chromium@npm:1.5.123"
+  checksum: 10c0/ffaa65e9337f5ba0b51d5709795c3d1074e0cae8efda24116561feed6cedd281f523be50339d991c2fc65344e66e65e7308a157ff87047a8bb4e8008412e9eb1
   languageName: node
   linkType: hard
 
@@ -2004,24 +2004,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import-x@npm:^4.9.0":
-  version: 4.9.0
-  resolution: "eslint-plugin-import-x@npm:4.9.0"
+"eslint-plugin-import-x@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "eslint-plugin-import-x@npm:4.9.1"
   dependencies:
     "@types/doctrine": "npm:^0.0.9"
-    "@typescript-eslint/utils": "npm:^8.26.1"
+    "@typescript-eslint/utils": "npm:^8.27.0"
     debug: "npm:^4.4.0"
     doctrine: "npm:^3.0.0"
     eslint-import-resolver-node: "npm:^0.3.9"
     get-tsconfig: "npm:^4.10.0"
-    picomatch: "npm:^4.0.2"
-    rspack-resolver: "npm:^1.2.1"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^10.0.1"
+    rspack-resolver: "npm:^1.2.2"
     semver: "npm:^7.7.1"
     stable-hash: "npm:^0.0.5"
     tslib: "npm:^2.8.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/bc0241fd956383474a16b9e366784c861e5ebe5b956d66b5f1c3d7cfe493e5863b90d3fe306e7065b11745853ea898e4232346472928bcc4c9ecc77bac3df13f
+  checksum: 10c0/07c433b70d264c757c1b8b337bd6c3146df61095bd3e290b07e3feb5b38e2f11aa0ecbe9633229cd942998b2bdeb40a47736128c017682befc030d4b5367c6ff
   languageName: node
   linkType: hard
 
@@ -2983,6 +2984,15 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: 10c0/5d3218dbd7db48b572925ddac05162a7415bf81b321f1a0c07016ec643cb5720c8a836ae68d45f5de826097a3013b601706c9c5aacb7f610dc2041b271de2ce0
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
   languageName: node
   linkType: hard
 
@@ -4091,7 +4101,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"rspack-resolver@npm:^1.2.1, rspack-resolver@npm:^1.2.2":
+"rspack-resolver@npm:^1.2.2":
   version: 1.2.2
   resolution: "rspack-resolver@npm:1.2.2"
   dependencies:
@@ -4414,11 +4424,11 @@ __metadata:
   linkType: hard
 
 "ts-api-utils@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "ts-api-utils@npm:2.0.1"
+  version: 2.1.0
+  resolution: "ts-api-utils@npm:2.1.0"
   peerDependencies:
     typescript: ">=4.8.4"
-  checksum: 10c0/23fd56a958b332cac00150a652e4c84730df30571bd2faa1ba6d7b511356d1a61656621492bb6c7f15dd6e18847a1408357a0e406671d358115369a17f5bfedd
+  checksum: 10c0/9806a38adea2db0f6aa217ccc6bc9c391ddba338a9fe3080676d0d50ed806d305bb90e8cef0276e793d28c8a929f400abb184ddd7ff83a416959c0f4d2ce754f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,7 +600,7 @@ __metadata:
     "@typescript-eslint/utils": "npm:^8.26.1"
     "@vitest/eslint-plugin": "npm:^1.1.38"
     eslint: "npm:^9.22.0"
-    eslint-import-resolver-typescript: "npm:^4.2.1"
+    eslint-import-resolver-typescript: "npm:^4.2.2"
     eslint-plugin-import-x: "npm:^4.8.1"
     eslint-plugin-jest-dom: "npm:^5.5.0"
     eslint-plugin-jsdoc: "npm:^50.6.8"
@@ -963,81 +963,81 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-darwin-arm64@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-darwin-arm64@npm:1.2.1"
+"@unrs/rspack-resolver-binding-darwin-arm64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-darwin-arm64@npm:1.2.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-darwin-x64@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-darwin-x64@npm:1.2.1"
+"@unrs/rspack-resolver-binding-darwin-x64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-darwin-x64@npm:1.2.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-freebsd-x64@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-freebsd-x64@npm:1.2.1"
+"@unrs/rspack-resolver-binding-freebsd-x64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-freebsd-x64@npm:1.2.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.2.1"
+"@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-linux-arm-gnueabihf@npm:1.2.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.2.1"
+"@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-linux-arm64-gnu@npm:1.2.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.2.1"
+"@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-linux-arm64-musl@npm:1.2.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.2.1"
+"@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-linux-x64-gnu@npm:1.2.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.2.1"
+"@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-linux-x64-musl@npm:1.2.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.2.1"
+"@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-wasm32-wasi@npm:1.2.2"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^0.2.7"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.2.1"
+"@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-win32-arm64-msvc@npm:1.2.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.2.1"
+"@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@unrs/rspack-resolver-binding-win32-x64-msvc@npm:1.2.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1979,13 +1979,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "eslint-import-resolver-typescript@npm:4.2.1"
+"eslint-import-resolver-typescript@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "eslint-import-resolver-typescript@npm:4.2.2"
   dependencies:
     debug: "npm:^4.4.0"
     get-tsconfig: "npm:^4.10.0"
-    rspack-resolver: "npm:^1.2.0"
+    rspack-resolver: "npm:^1.2.2"
     stable-hash: "npm:^0.0.5"
     tinyglobby: "npm:^0.2.12"
   peerDependencies:
@@ -2000,7 +2000,7 @@ __metadata:
       optional: true
     is-bun-module:
       optional: true
-  checksum: 10c0/38fb06767a6102d0724d60210de6c2292024c97492a22124d57e4cf58a4b730ad770efcbc9dd76c11c709fc69e0146d8469911f9c690bf072682a97d0a65cfc8
+  checksum: 10c0/ac6eea204e8dad2a802fbed4468040dd3a5e613d8693f44d8c4cc316c6019c1cc690369b32c567c32fd5f289b6d3102984863bf122290001dd9229cb8ed9ee3c
   languageName: node
   linkType: hard
 
@@ -4091,21 +4091,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"rspack-resolver@npm:^1.2.0, rspack-resolver@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "rspack-resolver@npm:1.2.1"
+"rspack-resolver@npm:^1.2.1, rspack-resolver@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "rspack-resolver@npm:1.2.2"
   dependencies:
-    "@unrs/rspack-resolver-binding-darwin-arm64": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-darwin-x64": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-freebsd-x64": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-linux-arm64-gnu": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-linux-arm64-musl": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-linux-x64-gnu": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-linux-x64-musl": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-wasm32-wasi": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-win32-arm64-msvc": "npm:1.2.1"
-    "@unrs/rspack-resolver-binding-win32-x64-msvc": "npm:1.2.1"
+    "@unrs/rspack-resolver-binding-darwin-arm64": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-darwin-x64": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-freebsd-x64": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-linux-arm64-gnu": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-linux-arm64-musl": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-linux-x64-gnu": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-linux-x64-musl": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-wasm32-wasi": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-win32-arm64-msvc": "npm:1.2.2"
+    "@unrs/rspack-resolver-binding-win32-x64-msvc": "npm:1.2.2"
   dependenciesMeta:
     "@unrs/rspack-resolver-binding-darwin-arm64":
       optional: true
@@ -4129,7 +4129,7 @@ __metadata:
       optional: true
     "@unrs/rspack-resolver-binding-win32-x64-msvc":
       optional: true
-  checksum: 10c0/9889d8a05ab3fcd546c2356a76bb5076b26ccb154c73d5427d3e78512704b7804273bd54b8694b152ad40de92c3b6667d02ad798d1b8baf855497ac67ea777f1
+  checksum: 10c0/897343b6e0934b54570722f1d21ca0239eaf0bdbad9b3357cc636a9cfc775f2b28f5fea477caf800978c22efed0f312ef2893d71c7b5e84447ac1ef9c5d80f22
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use `languageOptions.parserOptions.projectService = true` by default (instead of the previous `languageOptions.parserOptions.project = true`). [According to typescript-eslint team](https://typescript-eslint.io/blog/announcing-typescript-eslint-v8-beta#project-service), this is slightly faster with better support for TypeScript projects with references (which is what we use in our repositories).

---

- `@eslint-react/eslint-plugin`
    - [1.30.2](https://github.com/Rel1cx/eslint-react/releases/tag/v1.30.2)
    - [1.31.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.31.0)
    - [1.32.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.32.0)
    - [1.32.1](https://github.com/Rel1cx/eslint-react/releases/tag/v1.32.1)
    - [1.33.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.33.0)
    - [1.34.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.34.0)
    - [1.34.1](https://github.com/Rel1cx/eslint-react/releases/tag/v1.34.1)
    - [1.35.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.35.0)
    - [1.36.1](https://github.com/Rel1cx/eslint-react/releases/tag/v1.36.1)
    - [1.36.2](https://github.com/Rel1cx/eslint-react/releases/tag/v1.36.2)
    - [1.36.3](https://github.com/Rel1cx/eslint-react/releases/tag/v1.36.3)
    - [1.37.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.37.0)
    - [1.37.1](https://github.com/Rel1cx/eslint-react/releases/tag/v1.37.1)
    - [1.37.2](https://github.com/Rel1cx/eslint-react/releases/tag/v1.37.2)
    - [1.37.3](https://github.com/Rel1cx/eslint-react/releases/tag/v1.37.3)
    - [1.38.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.38.0)
- `@tanstack/eslint-plugin-query`
    - [5.67.2](https://github.com/TanStack/query/releases/tag/v5.67.2)
    - [5.68.0](https://github.com/TanStack/query/releases/tag/v5.68.0)
- `@vitest/eslint-plugin`
    - [1.1.37](https://github.com/vitest-dev/eslint-plugin-vitest/releases/tag/v1.1.37)
    - [1.1.38](https://github.com/vitest-dev/eslint-plugin-vitest/releases/tag/v1.1.38)
- `eslint`
    - [9.22.0](https://github.com/eslint/eslint/releases/tag/v9.22.0)
    - [9.23.0](https://github.com/eslint/eslint/releases/tag/v9.23.0)
- `eslint-import-resolver-typescript`
    - [3.8.4](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v3.8.4)
    - [3.8.5](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v3.8.5)
    - [3.8.6](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v3.8.6)
    - [3.8.7](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v3.8.7)
    - [3.9.0](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v3.9.0)
    - [3.9.1](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v3.9.1)
    - [4.0.0](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.0.0)
    - [4.1.0](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.1.0)
    - [4.1.1](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.1.1)
    - [4.2.0](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.2.0)
    - [4.2.1](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.2.1)
    - [4.2.2](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.2.2)
- `eslint-plugin-import-x`
    - [4.7.0](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.7.0)
    - [4.7.1](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.7.1)
    - [4.7.2](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.7.2)
    - [4.8.0](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.8.0)
    - [4.8.1](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.8.1)
    - [4.9.0](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.9.0)
    - [4.9.1](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.9.1)
- `eslint-plugin-jsdoc`
    - [50.6.4](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.4)
    - [50.6.5](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.5)
    - [50.6.6](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.6)
    - [50.6.7](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.7)
    - [50.6.8](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.8)
    - [50.6.9](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v50.6.9)
- `typescript-eslint`
    - [8.26.1](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.26.1)
    - [8.27.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.27.0)
    - [8.28.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.28.0)