### PR TITLE
@pandell/typescript-config: Switch "jsx" from "react" to "react-jsx"

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -24,7 +24,7 @@ import lib.*
  * mvn --file .teamcity teamcity-configs:generate
  */
 
-version = "2024.12"
+version = "2025.03"
 
 // Prefixes of packages included in this monorepo.
 enum class NpmPackagePrefix {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pandell/typescript-config",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Pandell Shared TypeScript Config",
   "keywords": [
     "pandell",

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -5,7 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "incremental": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -8,7 +8,7 @@
     "jsx": "react",
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Our current TypeScript settings use `"jsx": "react"` to control how JSX constructs get converted to JavaScript files. From documentation @ https://www.typescriptlang.org/tsconfig/#jsx:
> `react`: Emit `.js` files with JSX changed to the equivalent `React.createElement` calls

Also (notice the word "legacy"):
> Legacy React runtime: `"react"`
> ```js
> import React from 'react';
> export const HelloWorld = () => React.createElement("h1", null, "Hello world");
> ```

---

However, as of React 17 the recommended and preferred conversion method is `"jsx": "react-jsx"`. From official React announcement:
https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#whats-different-in-the-new-transform
> The old JSX transform turned JSX into React.createElement(...) calls.
> ...
> However, this is not perfect:

> - Because JSX was compiled into React.createElement, React needed to be in scope if you used JSX.
> - There are some [performance improvements and simplifications](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md#motivation) that React.createElement does not allow.

And from TypeScript documentation (notice how we only import a function, much better for tree-shaking):
> React: "react-jsx":
> ```js
> import { jsx as _jsx } from "react/jsx-runtime";
> export const HelloWorld = () => _jsx("h1", { children: "Hello world" });
> ```
---

This pull request updates our default `tsconfig.json` to use `"jsx": "react-jsx"`.

We should (in my opinion) propagate this change to `web-pli` before the React 19-enabled `web-pli` is published.