### PR TITLE
@pandell/postcss-config: Add optional "postcss" peer dependency

### DIFF
--- a/packages/postcss-config/package.json
+++ b/packages/postcss-config/package.json
@@ -34,6 +34,14 @@
     "@types/postcss-mixins": "^9.0.6",
     "postcss": "^8.5.3"
   },
+  "peerDependencies": {
+    "postcss": ">= 8"
+  },
+  "peerDependenciesMeta": {
+    "postcss": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/postcss-config/package.json
+++ b/packages/postcss-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/postcss-config",
   "type": "module",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Pandell PostCSS shared config",
   "keywords": [
     "postcss",

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,6 +636,11 @@ __metadata:
     postcss-calc: "npm:^10.1.1"
     postcss-mixins: "npm:^11.0.3"
     postcss-preset-env: "npm:^7.8.3"
+  peerDependencies:
+    postcss: ">= 8"
+  peerDependenciesMeta:
+    postcss:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Eliminates a `yarn install` warning.