### PR TITLE
Synchronize TypeScript config with Vite template as of May 2025

### DIFF
--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pandell/typescript-config",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Pandell Shared TypeScript Config",
   "keywords": [
     "pandell",

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -6,10 +6,13 @@
     "importHelpers": true,
     "incremental": true,
     "jsx": "react-jsx",
-    "lib": ["DOM", "ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "moduleDetection": "force",
     "moduleResolution": "bundler",
+    "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "noUncheckedSideEffectImports": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "removeComments": false,
@@ -17,6 +20,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "erasableSyntaxOnly": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,

--- a/packages/webpack-config/src/webpackConfig.ts
+++ b/packages/webpack-config/src/webpackConfig.ts
@@ -108,10 +108,10 @@ function envIsTrue(key: string): boolean {
 }
 
 class OpenBrowserPlugin implements WebpackPluginInstance {
-  constructor(
-    private readonly _openPage: string,
-    private readonly _openBrowser?: App | readonly App[],
-  ) {}
+  constructor(openPage: string, openBrowser?: App | readonly App[]) {
+    this._openPage = openPage;
+    this._openBrowser = openBrowser;
+  }
 
   apply(compiler: Compiler): void {
     compiler.hooks.done.tap("OpenBrowserPlugin", () => {
@@ -129,6 +129,8 @@ class OpenBrowserPlugin implements WebpackPluginInstance {
   }
 
   private _opened = false;
+  private readonly _openPage: string;
+  private readonly _openBrowser?: App | readonly App[];
 }
 
 /**


### PR DESCRIPTION
This pull request proposes changing our standard TypeScript configuration to be more in-line with Vite's recommended configuration for web applications as of May 2025. I updated `web-pli` to be compatible with this updated configuration.

Note: There is one additional option I would love to include in our TypeScript configuration, `"erasableSyntaxOnly": true`, but this requires not-insignificant refactoring in `web-pli` (we seem obsessed with `enum`). Going forward I strongly recommend not using deprecated TypeScript features like `enum`, and enabling `"erasableSyntaxOnly": true` wherever possible.