### PR TITLE
ESLint updates (wrong branch name)

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@eslint-react/eslint-plugin": "^1.50.0",
     "@eslint/js": "^9.27.0",
-    "@tanstack/eslint-plugin-query": "^5.74.7",
+    "@tanstack/eslint-plugin-query": "^5.78.0",
     "@typescript-eslint/utils": "^8.32.1",
     "@vitest/eslint-plugin": "^1.2.1",
     "eslint-import-resolver-typescript": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint-react/eslint-plugin": "npm:^1.50.0"
     "@eslint/js": "npm:^9.27.0"
-    "@tanstack/eslint-plugin-query": "npm:^5.74.7"
+    "@tanstack/eslint-plugin-query": "npm:^5.78.0"
     "@typescript-eslint/utils": "npm:^8.32.1"
     "@vitest/eslint-plugin": "npm:^1.2.1"
     eslint: "npm:^9.27.0"
@@ -684,14 +684,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/eslint-plugin-query@npm:^5.74.7":
-  version: 5.74.7
-  resolution: "@tanstack/eslint-plugin-query@npm:5.74.7"
+"@tanstack/eslint-plugin-query@npm:^5.78.0":
+  version: 5.78.0
+  resolution: "@tanstack/eslint-plugin-query@npm:5.78.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.18.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/7f026af15918e0f77e1032c0e53d70fd952d32735b0987a84d0df2b1c6b47ac01773da3812d579c999c398dd677d45400e133a1b3c2979e3f125028743451850
+  checksum: 10c0/b3276f5f365e61866f8e00b19cc096c285760ab25fbbed1663940484eddaf2810f7ce1a1d93f35dffe0e9d9ca40a52ad23322241530b68dd8b32b98dbcd9a4bf
   languageName: node
   linkType: hard
 
@@ -1872,9 +1872,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.149":
-  version: 1.5.155
-  resolution: "electron-to-chromium@npm:1.5.155"
-  checksum: 10c0/aee32a0b03282e488352370f6a910de37788b814031020a0e244943450e844e8a41f741d6e5ec70d553dfa4382ef80088034ddc400b48f45de95de331b9ec178
+  version: 1.5.158
+  resolution: "electron-to-chromium@npm:1.5.158"
+  checksum: 10c0/e6c435d495d3be523f81b5850956052f2e7ebc1a346444951b24fa974683c7d0b3e55fae854489d66d61ecf856f3f8d337a82835bb4b7b532ed25ada41e75070
   languageName: node
   linkType: hard
 
@@ -4440,19 +4440,19 @@ __metadata:
   linkType: hard
 
 "watchpack@npm:^2.4.1":
-  version: 2.4.3
-  resolution: "watchpack@npm:2.4.3"
+  version: 2.4.4
+  resolution: "watchpack@npm:2.4.4"
   dependencies:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
-  checksum: 10c0/212c645311d6c3a920ccca5b5d27233e8477be4352a20ae30c207e1bc71691154f1179316d31fb1135e56cc948bae8590a648fa9c05f088741c18ef613203475
+  checksum: 10c0/6c0901f75ce245d33991225af915eea1c5ae4ba087f3aee2b70dd377d4cacb34bef02a48daf109da9d59b2d31ec6463d924a0d72f8618ae1643dd07b95de5275
   languageName: node
   linkType: hard
 
 "webpack-sources@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "webpack-sources@npm:3.2.3"
-  checksum: 10c0/2ef63d77c4fad39de4a6db17323d75eb92897b32674e97d76f0a1e87c003882fc038571266ad0ef581ac734cbe20952912aaa26155f1905e96ce251adbb1eb4e
+  version: 3.3.0
+  resolution: "webpack-sources@npm:3.3.0"
+  checksum: 10c0/d9366eef6db95dffe154b6ffb50424c34f42d51ba3441efe9134642d13b0ccdf43897bdc7742f9f58eb4e834378f7ff67596137d3fca21ce34fe7cee8796e97a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `@eslint-react/eslint-plugin`
    - [1.50.0](https://github.com/Rel1cx/eslint-react/releases/tag/v1.50.0)
- `@tanstack/eslint-plugin-query`
    - [5.78.0](https://github.com/TanStack/query/releases/tag/v5.78.0)
- `@vitest/eslint-plugin`
    - [1.2.1](https://github.com/vitest-dev/eslint-plugin-vitest/releases/tag/v1.2.1)
- `eslint-plugin-import-x`
    - [4.13.0](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.13.0)
    - [4.13.1](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.13.1)
    - [4.13.2](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.13.2)
    - [4.13.3](https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.13.3)
- `eslint-import-resolver-typescript`
    - [4.4.0](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.4.0)
    - [4.4.1](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.4.1)
- `eslint-plugin-testing-library`
    - [7.2.2](https://github.com/testing-library/eslint-plugin-testing-library/releases/tag/v7.2.2)
